### PR TITLE
Implement ToSql for Postgres

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ byteorder = "0.5.3"
 serde = "0.8"
 serde_json = "0.8"
 lazy_static = "0.1.16"
-postgres = { version = "0.13.1", optional = true }
+postgres = { version = "0.13.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use] extern crate lazy_static;
 
+#[macro_use]
+#[cfg(feature = "postgres")]
+extern crate postgres as pg_crate;
 #[cfg(feature = "postgres")]
 mod postgres;
 
@@ -255,7 +258,7 @@ impl Decimal {
         if exp > MAX_PRECISION {
             panic!("Cannot have an exponent greater than {}", MAX_PRECISION);
         }
-        let diff = exp as i32 - ((self.flags & SCALE_MASK) >> SCALE_SHIFT);
+        let diff = exp as i32 - self.scale() as i32;
         if diff == 0 {
             // Since it's a copy type we can just return the self
             return *self;


### PR DESCRIPTION
I found this library because I need a type that can represent a numeric/decimal Postgres type, but discovered that the `postgres` feature wasn't fully implemented and didn't compile. This PR fixes the compilation issues and adds a `ToSql` implementation. The implementation may not be the most efficient, but it should be sufficiently fast for day-to-day use.