### PR TITLE
Bump dependencies, most notably postgres to 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 
 [dependencies]
 num = "0.1"
-byteorder = "0.5.3"
+byteorder = "1.0"
 serde = "0.9"
 serde_json = "0.9"
-lazy_static = "0.1.16"
-postgres = { version = "0.13.6", optional = true }
+lazy_static = "0.2"
+postgres = { version = "0.14", optional = true }

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -91,7 +91,7 @@ impl FromSql for Decimal {
     //   result = result + 5600 * 0.00000001;
     //
 
-    fn from_sql(_: &Type, raw: &[u8], _: &SessionInfo)
+    fn from_sql(_: &Type, raw: &[u8])
         -> Result<Decimal, Box<error::Error + 'static + Sync + Send>> {
         let mut raw = Cursor::new(raw);
         let num_groups = try!(raw.read_u16::<BigEndian>());
@@ -160,8 +160,7 @@ impl FromSql for Decimal {
 impl ToSql for Decimal {
     fn to_sql(&self,
               _: &Type,
-              out: &mut Vec<u8>,
-              _: &SessionInfo)
+              out: &mut Vec<u8>)
               -> Result<IsNull, Box<error::Error + 'static + Sync + Send>> {
         let uint = self.to_biguint();
         let sign = if self.is_negative() { 0x4000 } else { 0x0000 };


### PR DESCRIPTION
Note that postgres 0.14 is not backwards compatible with 0.13, because definitions of `from_sql` and `to_sql` have changed.