### PR TITLE
Add Travis YML for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+script:
+  - cargo build --verbose --all --all-features
+  - cargo test --verbose --all --all-features
+matrix:
+  allow_failures:
+    - rust: nightly


### PR DESCRIPTION
Note that the Travis builds are failing because of the Postgres component.

Related to #15.