### PR TITLE
Interoperation with f64

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -636,6 +636,26 @@ impl FromPrimitive for Decimal {
 }
 
 impl ToPrimitive for Decimal {
+
+    fn to_f64(&self) -> Option<f64> {
+        if self.scale() == 0 {
+            let bytes = self.unsigned_bytes_le();
+            let sign;
+            if self.is_negative() {
+                sign = Minus;
+            } else {
+                sign = Plus;
+            }
+            
+            BigInt::from_bytes_le(sign, &bytes[..]).to_f64()
+        } else {
+            match self.to_string().parse::<f64>() {
+                Ok(s) => Some(s),
+                Err(_) => None
+            }
+        }
+    }
+
     fn to_i64(&self) -> Option<i64> {
         let d = self.rescale(0);
         // Convert to biguint and use that

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -4,6 +4,7 @@ use serde;
 use std::fmt;
 use std::str::FromStr;
 use serde::de::Unexpected;
+use num::Zero;
 
 impl<'de> serde::Deserialize<'de> for Decimal {
     fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>
@@ -17,6 +18,13 @@ struct DecimalVisitor;
 
 impl<'de> serde::de::Visitor<'de> for DecimalVisitor {
     type Value = Decimal;
+
+    fn visit_f64<E>(self, value: f64) -> Result<Decimal, E> {
+        match Decimal::from_str(&value.to_string()) {
+            Ok(s) => Ok(s),
+            Err(_) => Ok(Decimal::zero()),
+        }
+    }
 
     fn visit_i64<E>(self, value: i64) -> Result<Decimal, E>
         where E: serde::de::Error

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -19,11 +19,10 @@ struct DecimalVisitor;
 impl<'de> serde::de::Visitor<'de> for DecimalVisitor {
     type Value = Decimal;
 
-    fn visit_f64<E>(self, value: f64) -> Result<Decimal, E> {
-        match Decimal::from_str(&value.to_string()) {
-            Ok(s) => Ok(s),
-            Err(_) => Ok(Decimal::zero()),
-        }
+    fn visit_f64<E>(self, value: f64) -> Result<Decimal, E> 
+        where E: serde::de::Error
+    {
+        Decimal::from_str(&value.to_string()).map_err(|_| E::invalid_value(Unexpected::Float(value), &self))
     }
 
     fn visit_i64<E>(self, value: i64) -> Result<Decimal, E>

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -4,6 +4,7 @@ extern crate rust_decimal;
 use num::Zero;
 use rust_decimal::Decimal;
 use std::str::FromStr;
+use num::ToPrimitive;
 
 // Parsing
 
@@ -657,4 +658,13 @@ fn it_can_go_from_and_into() {
     assert_eq!(du8, du32);
     assert_eq!(du32, dusize);
     assert_eq!(dusize, du64);
+}
+
+#[test]
+fn it_converts_to_f64() {
+    assert_eq!(5f64, Decimal::from_str("5").unwrap().to_f64().unwrap());
+    assert_eq!(-5f64, Decimal::from_str("-5").unwrap().to_f64().unwrap());
+    assert_eq!(0.1f64, Decimal::from_str("0.1").unwrap().to_f64().unwrap());
+    assert_eq!(0.25e-11f64, Decimal::from_str("0.0000000000025").unwrap().to_f64().unwrap());
+    assert_eq!(1e6f64, Decimal::from_str("1000000.0000000000025").unwrap().to_f64().unwrap());
 }


### PR DESCRIPTION
In order to calculate e.g. weighted averages of Decimal values, it is necessary to convert Decimals into floating point representation and accept the loss in precision.

Furthermore, it is a common use case to get financial data in JSON format. In order to automatically deserialize Decimals from JSON via serde I propose a visitor_f64.