### PR TITLE
Remove postgres from default feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ serde_json = "1.0"
 serde_derive = "1.0"
 
 [features]
-default = ["postgres","serde"]
+default = ["serde"]


### PR DESCRIPTION
Closes #42 - Posgres shouldn't be in the default feature set but can be enabled by using the feature flag "postgres".

This may be a breaking change for some users.