### PR TITLE
add basic benchmark against d128, closing #14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,6 @@ serde = { version = "1.0", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 serde_derive = "1.0"
-
+decimal = "2.0"
 [features]
 default = ["serde"]

--- a/benches/lib_benches.rs
+++ b/benches/lib_benches.rs
@@ -1,0 +1,44 @@
+#![feature(test)]
+
+extern crate test;
+extern crate rust_decimal;
+extern crate decimal;
+use test::Bencher;
+use rust_decimal::Decimal;
+use decimal::d128;
+use std::str::FromStr;
+
+macro_rules! bench_bin_op {
+    ($name:ident, $ty:ident, $op:tt) => {
+        #[bench]
+        fn $name(b: &mut Bencher) {
+            b.iter(|| {
+
+                let y = $ty::from_str("2").unwrap();
+                for _ in 0..100 {
+                    let mut x = y;
+                    for _ in 0..50 {
+                        x = x $op y;
+                    }
+                    test::black_box(x);
+                }
+            });
+        }
+
+    }
+}
+
+bench_bin_op!(bench_decimal_add, Decimal, +);
+bench_bin_op!(bench_d128_add, d128, +);
+
+
+bench_bin_op!(bench_decimal_sub, Decimal, -);
+bench_bin_op!(bench_d128_sub, d128, -);
+
+
+bench_bin_op!(bench_decimal_mul, Decimal, *);
+bench_bin_op!(bench_d128_mul, d128, *);
+
+bench_bin_op!(bench_decimal_div, Decimal, /);
+bench_bin_op!(bench_d128_div, d128, /);
+


### PR DESCRIPTION
Basic benchmarks comparing 4 primary ops to the d128 crate that is based on FFI to decNumber