### PR TITLE
Ordering fixes

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1910,7 +1910,7 @@ impl Ord for Decimal {
             return self.lo.cmp(&other.lo);
         }
 
-        if self_scale > other_scale {
+        if self_scale < other_scale {
             let c = self.rescale(other_scale);
             cmp_internal(&[c.lo, c.mid, c.hi], &[other.lo, other.mid, other.hi])
         } else {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2025,4 +2025,12 @@ mod test {
         let b = a.round_dp(2u32);
         assert_eq!("1982.27", b.to_string());
     }
+
+    #[test]
+    fn ordering() {
+        assert!(Decimal::from_str("0").unwrap() < Decimal::from_str("0.5").unwrap());
+        assert!(Decimal::from_str("0.5").unwrap() > Decimal::from_str("0").unwrap());
+        assert!(Decimal::from_str("100").unwrap() > Decimal::from_str("0.0098").unwrap());
+        assert!(Decimal::from_str("1000000000000000").unwrap() > Decimal::from_str("999000000000000.0001").unwrap());
+    }
 }


### PR DESCRIPTION
comparing 0 and 0.5 we were rescaling down 0.5 and fn rescale discards the div_by_u32 remainder so 0.5 got rescaled to 0
I added some tests that show the issue and then the fix which just reverses who gets rescaled so that the one with the smaller scale gets scaled up.