### PR TITLE
Fixes serde deserialization to use input data for type hinting

### DIFF
--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -9,7 +9,7 @@ impl<'de> serde::Deserialize<'de> for Decimal {
     fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>
     where
         D: serde::de::Deserializer<'de>, {
-        deserializer.deserialize_str(DecimalVisitor)
+        deserializer.deserialize_any(DecimalVisitor)
     }
 }
 


### PR DESCRIPTION
A change in serde 1.0.24 means that type information no longer behaves the same. The workaround is to use `deserialize_any` so that type information comes from the input data rather than the deserializer hint.