### PR TITLE
Introduce pre-calculated groups for Postgres

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -128,6 +128,31 @@ impl Decimal {
         }
     }
 
+    /// Returns a `Decimal` using the instances constituent parts.
+    ///
+    /// # Arguments
+    ///
+    /// * `lo` - The low 32 bits of a 96-bit integer.
+    /// * `mid` - The middle 32 bits of a 96-bit integer.
+    /// * `hi` - The high 32 bits of a 96-bit integer.
+    /// * `negative` - `true` to indicate a negative number.
+    /// * `scale` - A power of 10 ranging from 0 to 28.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// let _pi = Decimal::from_parts(3141u32, 0u32, 0u32, false, 3u32);
+    /// ```
+    pub fn from_parts(lo: u32, mid: u32, hi: u32, negative: bool, scale: u32) -> Decimal {
+        Decimal {
+            lo: lo,
+            mid: mid,
+            hi: hi,
+            flags: flags(negative, scale),
+        }
+    }
+
     /// Returns the scale of the decimal number, otherwise known as `e`.
     pub fn scale(&self) -> u32 {
         ((self.flags & SCALE_MASK) >> SCALE_SHIFT) as u32

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -138,6 +138,12 @@ impl FromSql for Decimal {
 
 impl ToSql for Decimal {
     fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<error::Error + 'static + Sync + Send>> {
+        // If it's zero we can short cut with a u64
+        if self.is_zero() {
+            out.write_u64::<BigEndian>(0)?;
+            return Ok(IsNull::No);
+        }
+
         let sign = if self.is_sign_negative() { 0x4000 } else { 0x0000 };
         let scale = self.scale() as u16;
 
@@ -312,6 +318,7 @@ mod test {
             &[
                 "3950.123456",
                 "3950",
+                "0",
                 "0.1",
                 "0.01",
                 "0.001",


### PR DESCRIPTION
Minor update to avoid calculation of groups each read. This should provide some performance improvements upon multiple reads.

Also, shortcuts the zero case for speed.

Fixes #81.