### PR TITLE
Added README to RustDocs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_decimal"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 
 description = "A Decimal Implementation written in pure Rust suitable for financial calculations."

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 A Decimal implementation written in pure Rust suitable for financial calculations that require significant integral and fractional digits with no round-off errors.
 
-The binary representation consists of a 96 bit integer number, a scaling factor used to specify the decimal fraction and a 1 bit sign. Because of this representation, trailing zeros are preserved and may be exposed when in string form. These can be truncated using the `round_dp` function.
+The binary representation consists of a 96 bit integer number, a scaling factor used to specify the decimal fraction and a 1 bit sign. Because of this representation, trailing zeros are preserved and may be exposed when in string form. These can be truncated using the `normalize` or `round_dp` functions.
 
 [Documentation](https://docs.rs/rust_decimal/)
 

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.8.1
+
+This release updates the published documentation only and is a no-op for functionality.
+
 ## 0.8.0
 
 * Introduces `from_scientific` allowing parsing of scientific notation into the Decimal type.

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -72,8 +72,8 @@ static BIG_POWERS_10: [u64; 10] = [
 ];
 
 /// `Decimal` represents a 128 bit representation of a fixed-precision decimal number.
-/// The finite set of values of type `Decimal` are of the form m / 10^e,
-/// where m is an integer such that -2^96 <= m <= 2^96, and e is an integer
+/// The finite set of values of type `Decimal` are of the form m / 10<sup>e</sup>,
+/// where m is an integer such that -2<sup>96</sup> <= m <= 2<sup>96</sup>, and e is an integer
 /// between 0 and 28 inclusive.
 #[derive(Clone, Copy, Debug)]
 pub struct Decimal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,12 @@
 //! Decimal numbers can be created in a few distinct ways, depending
 //! on the rust compiler version you're targeting.
 //!
-//! ### Stable
-//!
 //! The stable version of rust requires you to create a Decimal number
 //! using one of it's convenience methods.
 //!
 //! ```rust
 //! use rust_decimal::Decimal;
+//! use std::str::FromStr;
 //!
 //! // Using an integer followed by the decimal points
 //! let scaled = Decimal::new(202, 2); // 2.02
@@ -34,20 +33,6 @@
 //! // Using the raw decimal representation
 //! // 3.1415926535897932384626433832
 //! let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
-//! ```
-//!
-//! ### Nightly
-//!
-//! With the nightly version of rust you can use a procedural macro using
-//! the rust_decimal_macros crate. The advantage of this method is that the
-//! decimal numbers are parsed at compile time.
-//!
-//! ```rust
-//! // Procedural macros need importing directly
-//! use rust_decimal_macros::*;
-//!
-//! let number = dec!(-1.23);
-//!
 //! ```
 //!
 extern crate num;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! a scaling factor used to specify the decimal fraction and a 1
 //! bit sign. Because of this representation, trailing zeros are
 //! preserved and may be exposed when in string form. These can be
-//! truncated using the `round_dp` function.
+//! truncated using the `normalize` or `round_dp` functions.
 //!
 //! ## Usage
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,55 @@
+//!
+//! A Decimal implementation written in pure Rust suitable
+//! for financial calculations that require significant integral
+//! and fractional digits with no round-off errors.
+//!
+//! The binary representation consists of a 96 bit integer number,
+//! a scaling factor used to specify the decimal fraction and a 1
+//! bit sign. Because of this representation, trailing zeros are
+//! preserved and may be exposed when in string form. These can be
+//! truncated using the `round_dp` function.
+//!
+//! ## Usage
+//!
+//! Decimal numbers can be created in a few distinct ways, depending
+//! on the rust compiler version you're targeting.
+//!
+//! ### Stable
+//!
+//! The stable version of rust requires you to create a Decimal number
+//! using one of it's convenience methods.
+//!
+//! ```rust
+//! use rust_decimal::Decimal;
+//!
+//! // Using an integer followed by the decimal points
+//! let scaled = Decimal::new(202, 2); // 2.02
+//!
+//! // From a string representation
+//! let from_string = Decimal::from_str("2.02").unwrap(); // 2.02
+//!
+//! // Using the `Into` trait
+//! let my_int : Decimal = 3i32.into();
+//!
+//! // Using the raw decimal representation
+//! // 3.1415926535897932384626433832
+//! let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
+//! ```
+//!
+//! ### Nightly
+//!
+//! With the nightly version of rust you can use a procedural macro using
+//! the rust_decimal_macros crate. The advantage of this method is that the
+//! decimal numbers are parsed at compile time.
+//!
+//! ```rust
+//! // Procedural macros need importing directly
+//! use rust_decimal_macros::*;
+//!
+//! let number = dec!(-1.23);
+//!
+//! ```
+//!
 extern crate num;
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
This also fixes some cargo docs warnings and updates the version number for the main library only (for rustdoc updates).