### PR TITLE
optimize add

### DIFF
--- a/benches/lib_benches.rs
+++ b/benches/lib_benches.rs
@@ -31,6 +31,21 @@ bench_decimal_op!(add_negative_point_five, +, "-0.5");
 bench_decimal_op!(add_pi, +, "3.1415926535897932384626433832");
 bench_decimal_op!(add_negative_pi, +, "-3.1415926535897932384626433832");
 
+#[bench]
+fn bench_sum_10m(b: &mut ::test::Bencher) {
+    fn sum_10m(values: &[Decimal]) -> Decimal {
+        let mut sum: Decimal = 0.into();
+        for value in values {
+            sum = sum + value;
+        }
+        sum
+    }
+
+    let values: Vec<Decimal> = test::black_box((0..10_000_000).map(|i| i.into()).collect());
+    b.iter(|| sum_10m(&values));
+}
+
+
 /* Sub */
 bench_decimal_op!(sub_one, -, "1");
 bench_decimal_op!(sub_two, -, "2");
@@ -103,5 +118,5 @@ mod comparitive {
 }
 #[cfg(not(feature = "comparitive"))]
 mod comparitive {
-    
+
 }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1789,8 +1789,8 @@ impl<'a, 'b> Add<&'b Decimal> for &'a Decimal {
         let other_negative = other.is_sign_negative();
         let mut negative = false;
         let carry;
-        if my_negative && other_negative {
-            negative = true;
+        if !(my_negative ^ other_negative) {
+            negative = my_negative;
             carry = add3_internal(&mut my, &ot);
         } else if my_negative && !other_negative {
             // -x + y
@@ -1815,7 +1815,7 @@ impl<'a, 'b> Add<&'b Decimal> for &'a Decimal {
                 }
             }
             carry = 0;
-        } else if !my_negative && other_negative {
+        } else {
             // x + -y
             let cmp = cmp_internal(&my, &ot);
             // if x < y then it's negative (i.e. 1 + -2)
@@ -1838,8 +1838,6 @@ impl<'a, 'b> Add<&'b Decimal> for &'a Decimal {
                 }
             }
             carry = 0;
-        } else {
-            carry = add3_internal(&mut my, &ot);
         }
 
         // If we have a carry we underflowed.

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -899,15 +899,15 @@ fn add_internal(value: &mut [u32], by: &[u32]) -> u32 {
 
 #[inline]
 fn add3_internal(value: &mut [u32; 3], by: &[u32; 3]) -> u32 {
-    let mut carry: u64 = 0;
+    let mut carry: u32 = 0;
     let bl = by.len();
-    let mut sum: u64;
     for i in 0..bl {
-        sum = u64::from(value[i]) + u64::from(by[i]) + carry;
-        value[i] = (sum & U32_MASK) as u32;
-        carry = sum >> 32;
+        let res1 = value[i].overflowing_add(by[i]);
+        let res2 = res1.0.overflowing_add(carry);
+        value[i] = res2.0;
+        carry = (res1.1 | res2.1) as u32;
     }
-    carry as u32
+    carry
 }
 
 fn add_with_scale_internal(

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -897,6 +897,19 @@ fn add_internal(value: &mut [u32], by: &[u32]) -> u32 {
     carry as u32
 }
 
+#[inline]
+fn add3_internal(value: &mut [u32; 3], by: &[u32; 3]) -> u32 {
+    let mut carry: u64 = 0;
+    let bl = by.len();
+    let mut sum: u64;
+    for i in 0..bl {
+        sum = u64::from(value[i]) + u64::from(by[i]) + carry;
+        value[i] = (sum & U32_MASK) as u32;
+        carry = sum >> 32;
+    }
+    carry as u32
+}
+
 fn add_with_scale_internal(
     quotient: &mut [u32; 3],
     quotient_scale: &mut i32,
@@ -1778,7 +1791,7 @@ impl<'a, 'b> Add<&'b Decimal> for &'a Decimal {
         let carry;
         if my_negative && other_negative {
             negative = true;
-            carry = add_internal(&mut my, &ot);
+            carry = add3_internal(&mut my, &ot);
         } else if my_negative && !other_negative {
             // -x + y
             let cmp = cmp_internal(&my, &ot);
@@ -1826,7 +1839,7 @@ impl<'a, 'b> Add<&'b Decimal> for &'a Decimal {
             }
             carry = 0;
         } else {
-            carry = add_internal(&mut my, &ot);
+            carry = add3_internal(&mut my, &ot);
         }
 
         // If we have a carry we underflowed.


### PR DESCRIPTION
This changes gives improvements up to 22% in basic benchmarks

before
```
test add_negative_pi         ... bench:         169 ns/iter (+/- 2)
test add_negative_point_five ... bench:          28 ns/iter (+/- 0)
test add_one                 ... bench:          32 ns/iter (+/- 0)
test add_one_hundred         ... bench:          32 ns/iter (+/- 0)
test add_pi                  ... bench:         167 ns/iter (+/- 5)
test add_point_zero_one      ... bench:          18 ns/iter (+/- 0)
test add_two                 ... bench:          32 ns/iter (+/- 0)
```
after
```
test add_negative_pi         ... bench:         169 ns/iter (+/- 1)
test add_negative_point_five ... bench:          28 ns/iter (+/- 0)
test add_one                 ... bench:          28 ns/iter (+/- 0)
test add_one_hundred         ... bench:          28 ns/iter (+/- 1)
test add_pi                  ... bench:         163 ns/iter (+/- 2)
test add_point_zero_one      ... bench:          14 ns/iter (+/- 1)
test add_two                 ... bench:          28 ns/iter (+/- 0)
```

and huge win in added in PR benchmark 

before
```
test bench_sum_10m           ... bench: 150,744,073 ns/iter (+/- 2,652,292) 
```
after
```
test bench_sum_10m           ... bench:  78,743,056 ns/iter (+/- 1,843,435)
```
The same benchmark with sum of `decimal`s in C#\.net shows perf around 115 ms/iter