### PR TITLE
Update macros to use quote 0.6 as well as output raw format

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 
 [dependencies]
 rust_decimal = { path = "../", version = "0.10.1" }
-quote = "0.3"
+quote = "0.6"
 
 [lib]
 proc-macro = true

--- a/macros/tests/macro_tests.rs
+++ b/macros/tests/macro_tests.rs
@@ -6,9 +6,14 @@ use rust_decimal_macros::*;
 
 #[test]
 fn it_can_parse_decimal() {
-    assert_eq!("0.00", dec!(0.00).to_string());
-    assert_eq!("1.00", dec!(1.00).to_string());
-    assert_eq!("-1.23", dec!(-1.23).to_string());
-    assert_eq!("1.1234567890123456789012345678",
-        dec!(1.1234567890123456789012345678).to_string());
+    let tests = &[
+        ("0.00", dec!(0.00)),
+        ("1.00", dec!(1.00)),
+        ("-1.23", dec!(-1.23)),
+        ("1.1234567890123456789012345678", dec!(1.1234567890123456789012345678)),
+        ("1000000", dec!(1_000_000)),
+    ];
+    for &(a, b) in tests {
+        assert_eq!(a, b.to_string());
+    }
 }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -75,11 +75,11 @@ static BIG_POWERS_10: [u64; 10] = [
 /// of decimal-format stored in it's own field
 #[derive(Clone, Copy, Debug)]
 pub struct UnpackedDecimal {
-    is_negative: bool,
-    scale: u32,
-    hi: u32,
-    mid: u32,
-    lo: u32
+    pub is_negative: bool,
+    pub scale: u32,
+    pub hi: u32,
+    pub mid: u32,
+    pub lo: u32
 }
 
 /// `Decimal` represents a 128 bit representation of a fixed-precision decimal number.


### PR DESCRIPTION
This updates rust macros to use `quote` version `0.6`. Accordingly, I've also changed the resulting output to use `from_parts` via the `UnpackedDecimal` type. This required making the properties of this public so that users can leverage the internals if they so wish. Most notably, I rely on this within the macro crate. 