### PR TITLE
Fix parsing when underscore separators precede a decimal point

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1501,8 +1501,7 @@ impl FromStr for Decimal {
         }
 
         // should now be at numeric part of the significand
-        let mut dot_offset: i32 = -1; // '.' offset, -1 if none
-        let cfirst = offset; // record start of integer
+        let mut digits_before_dot: i32 = -1; // digits before '.', -1 if no '.'
         let mut coeff = Vec::new(); // integer significand array
 
         while len > 0 {
@@ -1533,7 +1532,7 @@ impl FromStr for Decimal {
                                                 coeff[index] = 0;
                                                 if index == 0 {
                                                     coeff.insert(0, 1u32);
-                                                    dot_offset += 1;
+                                                    digits_before_dot += 1;
                                                     coeff.pop();
                                                     break;
                                                 }
@@ -1545,7 +1544,7 @@ impl FromStr for Decimal {
                                 b'_' => {}
                                 b'.' => {
                                     // Still an error if we have a second dp
-                                    if dot_offset >= 0 {
+                                    if digits_before_dot >= 0 {
                                         return Err(Error::new("Invalid decimal: two decimal points"));
                                     }
                                 }
@@ -1556,10 +1555,10 @@ impl FromStr for Decimal {
                     }
                 }
                 b'.' => {
-                    if dot_offset >= 0 {
+                    if digits_before_dot >= 0 {
                         return Err(Error::new("Invalid decimal: two decimal points"));
                     }
-                    dot_offset = offset as i32;
+                    digits_before_dot = coeff.len() as i32;
                     offset += 1;
                     len -= 1;
                 }
@@ -1580,9 +1579,9 @@ impl FromStr for Decimal {
             return Err(Error::new("Invalid decimal: no digits found"));
         }
 
-        let mut scale = if dot_offset >= 0 {
+        let mut scale = if digits_before_dot >= 0 {
             // we had a decimal place so set the scale
-            (coeff.len() as u32) - (dot_offset as u32 - cfirst as u32)
+            (coeff.len() as u32) - (digits_before_dot as u32)
         } else {
             0
         };

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1012,6 +1012,14 @@ fn it_can_parse_alternative_formats() {
 }
 
 #[test]
+fn it_can_parse_fractional_numbers_with_underscore_separators() {
+    let a = Decimal::from_str("0.1_23_456").unwrap();
+    assert_eq!(a.is_sign_negative(), false);
+    assert_eq!(a.scale(), 6);
+    assert_eq!("0.123456", a.to_string());
+}
+
+#[test]
 fn it_can_reject_invalid_formats() {
     let tests = &["_1", "1.0.0", "10_00.0_00.0"];
     for &value in tests {

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1020,6 +1020,26 @@ fn it_can_parse_fractional_numbers_with_underscore_separators() {
 }
 
 #[test]
+fn it_can_parse_numbers_with_underscore_separators_before_decimal_point() {
+    let a = Decimal::from_str("1_234.56").unwrap();
+    assert_eq!(a.is_sign_negative(), false);
+    assert_eq!(a.scale(), 2);
+    assert_eq!("1234.56", a.to_string());
+}
+
+#[test]
+fn it_can_parse_numbers_and_round_correctly_with_underscore_separators_before_decimal_point() {
+    let tests = &[
+        ("8_097_370_036_018_690_744.2590371159596744091", "8097370036018690744.259037116"),
+        ("8097370036018690744.259_037_115_959_674_409_1", "8097370036018690744.259037116"),
+        ("8_097_370_036_018_690_744.259_037_115_959_674_409_1", "8097370036018690744.259037116"),
+    ];
+    for &(value, expected) in tests {
+        assert_eq!(expected, Decimal::from_str(value).unwrap().to_string());
+    }
+}
+
+#[test]
 fn it_can_reject_invalid_formats() {
     let tests = &["_1", "1.0.0", "10_00.0_00.0"];
     for &value in tests {


### PR DESCRIPTION
This fixes the parsing of numbers like "1_234.56" which have an "_" separator followed later by a decimal point. Currently this number is incorrectly parsed as equivalent to "12345.6" instead of "1234.56".

The incorrect value arises because the determination of the scale in `Decimal::from_str` made reference to the difference between the offsets of the start of the number and the decimal point, causing "_" separators to incorrectly affect the scale.

This PR fixes the problem by changing `Decimal::from_str` to remember the number of digits preceding the decimal point, rather than offsets.