### PR TITLE
Use proc-macro-hack to allow dec! in expr position

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_script:
   - "./.travis/setup.sh"
 
 script:
-  - cargo build --verbose -p rust_decimal --all-features
-  - cargo test --verbose -p rust_decimal --all-features
+  - cargo build --verbose -p rust_decimal -p rust_decimal_macros --all-features
+  - cargo test --verbose -p rust_decimal -p rust_decimal_macros --all-features
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,18 +12,13 @@ before_script:
   - "./.travis/setup.sh"
 
 script:
-  - cargo build --verbose -p rust_decimal -p rust_decimal_macros --all-features
-  - cargo test --verbose -p rust_decimal -p rust_decimal_macros --all-features
+  - cargo build --verbose --all --all-features
+  - cargo test --verbose --all --all-features
 
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
-  include:
-      - rust: nightly
-        script:
-          - cargo build --verbose --all --all-features
-          - cargo test --verbose --all --all-features
 
 notifications:
   email:

--- a/macro_impl/Cargo.toml
+++ b/macro_impl/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "rust_decimal_macros"
+name = "rust_decimal_macro_impls"
 version = "0.10.2"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 
-description = "Shorthand macros to assist creating Decimal types."
+description = "Shorthand macros to assist creating Decimal types. Do not depend on this directly; use rust_decimal_macros"
 documentation = "https://docs.rs/rust_decimal/"
 repository = "https://github.com/paupino/rust-decimal"
 readme = "../README.md"
@@ -17,6 +17,9 @@ license = "MIT"
 travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 
 [dependencies]
-rust_decimal = { path = "..", version = "0.10.2" }
-rust_decimal_macro_impls = { path = "../macro_impl", version = "0.10.2" }
+rust_decimal = { path = "../", version = "0.10.2" }
 proc-macro-hack = "0.5"
+quote = "0.6"
+
+[lib]
+proc-macro = true

--- a/macro_impl/LICENSE
+++ b/macro_impl/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Paul Mason
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/macro_impl/src/lib.rs
+++ b/macro_impl/src/lib.rs
@@ -1,0 +1,38 @@
+extern crate proc_macro;
+extern crate proc_macro_hack;
+extern crate rust_decimal;
+extern crate quote;
+
+use proc_macro::TokenStream;
+use proc_macro_hack::proc_macro_hack;
+use quote::quote;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+
+#[proc_macro_hack]
+pub fn dec(input: TokenStream) -> TokenStream {
+    let mut source = input.to_string();
+
+    // If it starts with `- ` then get rid of the extra space
+    // to_string will put a space between tokens
+    if source.starts_with("- ") {
+        source.remove(1);
+    }
+
+    let decimal = match Decimal::from_str(&source[..]) {
+        Ok(d) => d,
+        Err(e) => panic!("Unexpected decimal format for {}: {}", source, e),
+    };
+
+    let unpacked = decimal.unpack();
+    // We need to further unpack these for quote for now
+    let lo = unpacked.lo;
+    let mid = unpacked.mid;
+    let hi = unpacked.hi;
+    let negative = unpacked.is_negative;
+    let scale = unpacked.scale;
+    let expanded = quote! {
+        ::rust_decimal::Decimal::from_parts(#lo, #mid, #hi, #negative, #scale)
+    };
+    expanded.into()
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,36 +1,7 @@
-extern crate rust_decimal;
-extern crate proc_macro;
-#[macro_use]
-extern crate quote;
+extern crate proc_macro_hack;
+extern crate rust_decimal_macro_impls;
 
-use proc_macro::TokenStream;
-use rust_decimal::Decimal;
-use std::str::FromStr;
+use proc_macro_hack::proc_macro_hack;
 
-#[proc_macro]
-pub fn dec(input: TokenStream) -> TokenStream {
-    let mut source = input.to_string();
-
-    // If it starts with `- ` then get rid of the extra space
-    // to_string will put a space between tokens
-    if source.starts_with("- ") {
-        source.remove(1);
-    }
-
-    let decimal = match Decimal::from_str(&source[..]) {
-        Ok(d) => d,
-        Err(e) => panic!("Unexpected decimal format for {}: {}", source, e),
-    };
-
-    let unpacked = decimal.unpack();
-    // We need to further unpack these for quote for now
-    let lo = unpacked.lo;
-    let mid = unpacked.mid;
-    let hi = unpacked.hi;
-    let negative = unpacked.is_negative;
-    let scale = unpacked.scale;
-    let expanded = quote! {
-        ::rust_decimal::Decimal::from_parts(#lo, #mid, #hi, #negative, #scale)
-    };
-    expanded.into()
-}
+#[proc_macro_hack]
+pub use rust_decimal_macro_impls::dec;

--- a/macros/tests/macro_tests.rs
+++ b/macros/tests/macro_tests.rs
@@ -1,8 +1,7 @@
-#![feature(proc_macro_hygiene)]
 extern crate rust_decimal;
 extern crate rust_decimal_macros;
 
-use rust_decimal_macros::*;
+use rust_decimal_macros::dec;
 
 #[test]
 fn it_can_parse_decimal() {


### PR DESCRIPTION
Added a new crate `rust_decimal_macro_impls` to hold the implementation,
re-exporting the procedural macro through `rust_decimal_macros` in order
to fit the pattern for using the `proc-macro-hack` crate.