### PR TITLE
Fixes bug in floor/ceil where negative numbers were incorrectly handled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_decimal"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 
 description = "A Decimal Implementation written in pure Rust suitable for financial calculations."

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 0.11.1
+
+* Fixes a bug in `floor` and `ceil` where negative numbers were incorrectly handled.
+
 ## 0.11.0
 
 * Macros are now supported on stable. This does use a [hack](https://github.com/dtolnay/proc-macro-hack) for the meantime 

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_decimal_fuzzer"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 
 [[bin]]

--- a/macro_impl/Cargo.toml
+++ b/macro_impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_decimal_macro_impls"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 
 description = "Shorthand macros to assist creating Decimal types. Do not depend on this directly; use rust_decimal_macros"
@@ -17,7 +17,7 @@ license = "MIT"
 travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 
 [dependencies]
-rust_decimal = { path = "../", version = "0.11.0" }
+rust_decimal = { path = "../", version = "0.11.1" }
 proc-macro-hack = "0.5"
 quote = "0.6"
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_decimal_macros"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 
 description = "Shorthand macros to assist creating Decimal types."
@@ -17,6 +17,6 @@ license = "MIT"
 travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 
 [dependencies]
-rust_decimal = { path = "..", version = "0.11.0" }
-rust_decimal_macro_impls = { path = "../macro_impl", version = "0.11.0" }
+rust_decimal = { path = "..", version = "0.11.1" }
+rust_decimal_macro_impls = { path = "../macro_impl", version = "0.11.1" }
 proc-macro-hack = "0.5"

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -597,8 +597,19 @@ impl Decimal {
     /// assert_eq!(num.floor().to_string(), "3");
     /// ```
     pub fn floor(&self) -> Decimal {
+        let scale = self.scale();
+        if scale == 0 {
+            // Nothing to do
+            return *self;
+        }
+
         // Opportunity for optimization here
-        self.trunc()
+        let floored = self.trunc();
+        if self.is_sign_negative() && !self.fract().is_zero() {
+            floored - Decimal::one()
+        } else {
+            floored
+        }
     }
 
     /// Returns the smallest integer greater than or equal to a number.
@@ -614,11 +625,17 @@ impl Decimal {
     /// assert_eq!(num.ceil().to_string(), "3");
     /// ```
     pub fn ceil(&self) -> Decimal {
+        let scale = self.scale();
+        if scale == 0 {
+            // Nothing to do
+            return *self;
+        }
+
         // Opportunity for optimization here
-        if self.fract().is_zero() {
-            *self
-        } else {
+        if self.is_sign_positive() && !self.fract().is_zero() {
             self.trunc() + Decimal::one()
+        } else {
+            self.trunc()
         }
     }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -556,6 +556,38 @@ fn it_cmps_decimals() {
 }
 
 #[test]
+fn it_floors_decimals() {
+    let tests = &[
+        ("1", "1"),
+        ("1.00", "1"),
+        ("1.2345", "1"),
+        ("-1", "-1"),
+        ("-1.00", "-1"),
+        ("-1.2345", "-2"),
+    ];
+    for &(a, expected) in tests {
+        let a = Decimal::from_str(a).unwrap();
+        assert_eq!(expected, a.floor().to_string(), "Failed flooring {}", a);
+    }
+}
+
+#[test]
+fn it_ceils_decimals() {
+    let tests = &[
+        ("1", "1"),
+        ("1.00", "1"),
+        ("1.2345", "2"),
+        ("-1", "-1"),
+        ("-1.00", "-1"),
+        ("-1.2345", "-1"),
+    ];
+    for &(a, expected) in tests {
+        let a = Decimal::from_str(a).unwrap();
+        assert_eq!(expected, a.ceil().to_string(), "Failed ceiling {}", a);
+    }
+}
+
+#[test]
 fn test_max_compares() {
     let x = "225.33543601344182".parse::<Decimal>().unwrap();
     let y = Decimal::max_value();


### PR DESCRIPTION
Fixes #156 
Previously, floor and ceiling were incorrectly handling negative numbers. Namely, `-1.23` would be floored to `-1` instead of `-2`. Equivalently, another issue was discovered whereby `1.00` would not be ceiled to `1` but instead `1.00`. 