### PR TITLE
Added Assignment Operators for References

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,3 +1,4 @@
+
 use crate::Error;
 
 use num::{FromPrimitive, One, ToPrimitive, Zero};
@@ -2172,6 +2173,24 @@ impl AddAssign for Decimal {
     }
 }
 
+impl<'a> AddAssign<&'a Decimal> for Decimal {
+    fn add_assign(&mut self, other: &'a Decimal) {
+        Decimal::add_assign(self, *other)
+    }
+}
+
+impl<'a> AddAssign<Decimal> for &'a mut Decimal {
+    fn add_assign(&mut self, other: Decimal) {
+        Decimal::add_assign(*self, other)
+    }
+}
+
+impl<'a> AddAssign<&'a Decimal> for &'a mut Decimal {
+    fn add_assign(&mut self, other: &'a Decimal) {
+        Decimal::add_assign(*self, *other)
+    }
+}
+
 forward_all_binop!(impl Sub for Decimal, sub);
 
 impl<'a, 'b> Sub<&'b Decimal> for &'a Decimal {
@@ -2196,6 +2215,24 @@ impl SubAssign for Decimal {
         self.mid = result.mid;
         self.hi = result.hi;
         self.flags = result.flags;
+    }
+}
+
+impl<'a> SubAssign<&'a Decimal> for Decimal {
+    fn sub_assign(&mut self, other: &'a Decimal) {
+        Decimal::sub_assign(self, *other)
+    }
+}
+
+impl<'a> SubAssign<Decimal> for &'a mut Decimal {
+    fn sub_assign(&mut self, other: Decimal) {
+        Decimal::sub_assign(*self, other)
+    }
+}
+
+impl<'a> SubAssign<&'a Decimal> for &'a mut Decimal {
+    fn sub_assign(&mut self, other: &'a Decimal) {
+        Decimal::sub_assign(*self, *other)
     }
 }
 
@@ -2387,6 +2424,24 @@ impl MulAssign for Decimal {
     }
 }
 
+impl<'a> MulAssign<&'a Decimal> for Decimal {
+    fn mul_assign(&mut self, other: &'a Decimal) {
+        Decimal::mul_assign(self, *other)
+    }
+}
+
+impl<'a> MulAssign<Decimal> for &'a mut Decimal {
+    fn mul_assign(&mut self, other: Decimal) {
+        Decimal::mul_assign(*self, other)
+    }
+}
+
+impl<'a> MulAssign<&'a Decimal> for &'a mut Decimal {
+    fn mul_assign(&mut self, other: &'a Decimal) {
+        Decimal::mul_assign(*self, *other)
+    }
+}
+
 forward_all_binop!(impl Div for Decimal, div);
 
 impl<'a, 'b> Div<&'b Decimal> for &'a Decimal {
@@ -2523,6 +2578,25 @@ impl DivAssign for Decimal {
     }
 }
 
+impl<'a> DivAssign<&'a Decimal> for Decimal {
+    fn div_assign(&mut self, other: &'a Decimal) {
+        Decimal::div_assign(self, *other)
+    }
+}
+
+impl<'a> DivAssign<Decimal> for &'a mut Decimal {
+    fn div_assign(&mut self, other: Decimal) {
+        Decimal::div_assign(*self, other)
+    }
+}
+
+impl<'a> DivAssign<&'a Decimal> for &'a mut Decimal {
+    fn div_assign(&mut self, other: &'a Decimal) {
+        Decimal::div_assign(*self, *other)
+    }
+}
+
+
 forward_all_binop!(impl Rem for Decimal, rem);
 
 impl<'a, 'b> Rem<&'b Decimal> for &'a Decimal {
@@ -2561,6 +2635,24 @@ impl RemAssign for Decimal {
         self.mid = result.mid;
         self.hi = result.hi;
         self.flags = result.flags;
+    }
+}
+
+impl<'a> RemAssign<&'a Decimal> for Decimal {
+    fn rem_assign(&mut self, other: &'a Decimal) {
+        Decimal::rem_assign(self, *other)
+    }
+}
+
+impl<'a> RemAssign<Decimal> for &'a mut Decimal {
+    fn rem_assign(&mut self, other: Decimal) {
+        Decimal::rem_assign(*self, other)
+    }
+}
+
+impl<'a> RemAssign<&'a Decimal> for &'a mut Decimal {
+    fn rem_assign(&mut self, other: &'a Decimal) {
+        Decimal::rem_assign(*self, *other)
     }
 }
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,4 +1,3 @@
-
 use crate::Error;
 
 use num::{FromPrimitive, One, ToPrimitive, Zero};

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -283,6 +283,17 @@ fn it_can_addassign() {
     let b = Decimal::from_str("0.99").unwrap();
     a += b;
     assert_eq!("2.00", a.to_string());
+
+    a += &b;
+    assert_eq!("2.99", a.to_string());
+
+    let mut c = &mut a;
+    c += b;
+    assert_eq!("3.98", a.to_string());
+
+    let mut c = &mut a;
+    c += &b;
+    assert_eq!("4.97", a.to_string());
 }
 
 // Subtraction
@@ -329,6 +340,17 @@ fn it_can_subassign() {
     let b = Decimal::from_str("0.51").unwrap();
     a -= b;
     assert_eq!("0.50", a.to_string());
+
+    a -= &b;
+    assert_eq!("-0.01", a.to_string());
+
+    let mut c = &mut a;
+    c -= b;
+    assert_eq!("-0.52", a.to_string());
+
+    let mut c = &mut a;
+    c -= &b;
+    assert_eq!("-1.03", a.to_string());
 }
 
 // Multiplication
@@ -404,8 +426,20 @@ fn it_panics_when_multiply_with_overflow() {
 fn it_can_mulassign() {
     let mut a = Decimal::from_str("1.25").unwrap();
     let b = Decimal::from_str("0.01").unwrap();
+
     a *= b;
     assert_eq!("0.0125", a.to_string());
+
+    a *= &b;
+    assert_eq!("0.000125", a.to_string());
+
+    let mut c = &mut a;
+    c *= b;
+    assert_eq!("0.00000125", a.to_string());
+
+    let mut c = &mut a;
+    c *= &b;
+    assert_eq!("0.0000000125", a.to_string());
 }
 
 // Division
@@ -450,8 +484,20 @@ fn it_can_divide_by_zero() {
 fn it_can_divassign() {
     let mut a = Decimal::from_str("1.25").unwrap();
     let b = Decimal::from_str("0.01").unwrap();
+
     a /= b;
     assert_eq!("125", a.to_string());
+
+    a /= &b;
+    assert_eq!("12500", a.to_string());
+
+    let mut c = &mut a;
+    c /= b;
+    assert_eq!("1250000", a.to_string());
+
+    let mut c = &mut a;
+    c /= &b;
+    assert_eq!("125000000", a.to_string());
 }
 
 // Modulus and Remainder are not the same thing!
@@ -483,7 +529,19 @@ fn it_rems_decimals() {
 fn it_can_remassign() {
     let mut a = Decimal::from_str("5").unwrap();
     let b = Decimal::from_str("2").unwrap();
+
     a %= b;
+    assert_eq!("1", a.to_string());
+
+    a %= &b;
+    assert_eq!("1", a.to_string());
+
+    let mut c = &mut a;
+    c %= b;
+    assert_eq!("1", a.to_string());
+
+    let mut c = &mut a;
+    c %= &b;
     assert_eq!("1", a.to_string());
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1,12 +1,11 @@
 extern crate num;
 extern crate rust_decimal;
 
-use num::ToPrimitive;
-use num::Zero;
+use num::{ToPrimitive, Zero};
+
 use rust_decimal::{Decimal, RoundingStrategy};
-use std::cmp::Ordering;
-use std::cmp::Ordering::*;
-use std::str::FromStr;
+
+use std::{cmp::{Ordering, Ordering::*}, str::FromStr};
 
 // Parsing
 


### PR DESCRIPTION
* Added support for assignment operations where the RHS is a reference. This is consistent with the `std` primitive types. 

* Added support for cases where the LHS is a mutable reference. This is more esoteric and not consistent with the `std` primitive types. I would argue that it is still quite useful. For instance, one could use this operator to increment a `Decimal` contained in a `HashMap` directly via its mutable reference.

* Added unit tests for these operators.