### PR TITLE
Fixes overflow when parsing min values for i32/164

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1810,16 +1810,16 @@ impl FromStr for Decimal {
 impl FromPrimitive for Decimal {
     fn from_i32(n: i32) -> Option<Decimal> {
         let flags: u32;
-        let value_copy: i32;
+        let value_copy: i64;
         if n >= 0 {
             flags = 0;
-            value_copy = n;
+            value_copy = n as i64;
         } else {
             flags = SIGN_MASK;
-            value_copy = -n;
+            value_copy = -(n as i64);
         }
         Some(Decimal {
-            flags: flags,
+            flags,
             lo: value_copy as u32,
             mid: 0,
             hi: 0,
@@ -1828,16 +1828,16 @@ impl FromPrimitive for Decimal {
 
     fn from_i64(n: i64) -> Option<Decimal> {
         let flags: u32;
-        let value_copy: i64;
+        let value_copy: i128;
         if n >= 0 {
             flags = 0;
-            value_copy = n;
+            value_copy = n as i128;
         } else {
             flags = SIGN_MASK;
-            value_copy = -n;
+            value_copy = -(n as i128);
         }
         Some(Decimal {
-            flags: flags,
+            flags,
             lo: value_copy as u32,
             mid: (value_copy >> 32) as u32,
             hi: 0,

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -663,6 +663,43 @@ fn test_min_compares() {
 }
 
 #[test]
+fn it_can_parse_from_i32() {
+    use num::FromPrimitive;
+
+    let tests = &[
+        (0i32, "0"),
+        (1i32, "1"),
+        (-1i32, "-1"),
+        (i32::max_value(), "2147483647"),
+        (i32::min_value(), "-2147483648"),
+    ];
+    for &(input, expected) in tests {
+        let parsed = Decimal::from_i32(input).unwrap();
+        assert_eq!(expected, parsed.to_string(), "expected {} does not match parsed {}", expected, parsed);
+        assert_eq!(input.to_string(), parsed.to_string(), "i32 to_string {} does not match parsed {}", input, parsed);
+    }
+}
+
+#[test]
+fn it_can_parse_from_i64() {
+    use num::FromPrimitive;
+
+    let tests = &[
+        (0i64, "0"),
+        (1i64, "1"),
+        (-1i64, "-1"),
+        (i64::max_value(), "9223372036854775807"),
+        (i64::min_value(), "-9223372036854775808"),
+    ];
+    for &(input, expected) in tests {
+        let parsed = Decimal::from_i64(input).unwrap();
+        assert_eq!(expected, parsed.to_string(), "expected {} does not match parsed {}", expected, parsed);
+        assert_eq!(input.to_string(), parsed.to_string(), "i64 to_string {} does not match parsed {}", input, parsed);
+    }
+
+}
+
+#[test]
 fn it_can_round_to_2dp() {
     let a = Decimal::from_str("6.12345").unwrap();
     let b = (Decimal::from_str("100").unwrap() * a).round() / Decimal::from_str("100").unwrap();


### PR DESCRIPTION
This largely adds some tests and leverages the next size up integer to support overflowing minimums.
This is required because we need to strip the "-" from the i32/i64 however this is also typically +1 the maximum.

We could look at potentially leveraging the unsigned equivalent, however it's a little less trivial than removing the sign bit (e.g. think 2s complement for -1).

Accordingly, for now, the simplest solution is to simply convert it using bigger storage! It's a little inefficient considering we only need one more bit however it's a quick solution that fixes #171.