### PR TITLE
Makes `const_fn` a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 [dependencies]
 num = "0.2"
 byteorder = "1.3"
-lazy_static = { version = "1.3", optional = true }
 postgres = { version = "0.15", optional = true }
 serde = { version = "1.0", optional = true }
 
@@ -30,8 +29,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 
 [features]
-default = ["serde", "lazy_static"]
-const_fn = []
+default = ["serde"]
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]

--- a/README.md
+++ b/README.md
@@ -44,14 +44,8 @@ let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
 ## Features
 
 * [postgres](#postgres)
-* [const_fn](#const_fn)
 
 ## `postgres`
 
 This feature enables a PostgreSQL communication module. It allows for reading and writing the `Decimal`
-type by transparently serializing/deserializing into the `NUMERIC` data type within PostgreSQL. 
-
-## `const_fn`
-
-This feature leverages constant functions within Rust which enables some performance optimizations
-at compile time. This feature is expected to become a default in future versions.
+type by transparently serializing/deserializing into the `NUMERIC` data type within PostgreSQL.

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2,9 +2,6 @@ use crate::Error;
 
 use num::{FromPrimitive, One, ToPrimitive, Zero};
 
-#[cfg(not(feature = "const_fn"))]
-use lazy_static::lazy_static;
-
 use std::{
     cmp::{Ordering::Equal, *},
     fmt,
@@ -37,23 +34,6 @@ const MAX_PRECISION: u32 = 28;
 
 static ONE_INTERNAL_REPR: [u32; 3] = [1, 0, 0];
 
-#[cfg(not(feature = "const_fn"))]
-lazy_static! {
-    static ref MIN: Decimal = Decimal {
-        flags: 2_147_483_648,
-        lo: 4_294_967_295,
-        mid: 4_294_967_295,
-        hi: 4_294_967_295
-    };
-    static ref MAX: Decimal = Decimal {
-        flags: 0,
-        lo: 4_294_967_295,
-        mid: 4_294_967_295,
-        hi: 4_294_967_295
-    };
-}
-
-#[cfg(feature = "const_fn")]
 const MIN: Decimal = Decimal {
     flags: 2_147_483_648,
     lo: 4_294_967_295,
@@ -61,7 +41,6 @@ const MIN: Decimal = Decimal {
     hi: 4_294_967_295,
 };
 
-#[cfg(feature = "const_fn")]
 const MAX: Decimal = Decimal {
     flags: 0,
     lo: 4_294_967_295,
@@ -200,36 +179,7 @@ impl Decimal {
     /// let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
     /// assert_eq!(pi.to_string(), "3.1415926535897932384626433832");
     /// ```
-    #[cfg(feature = "const_fn")]
     pub const fn from_parts(lo: u32, mid: u32, hi: u32, negative: bool, scale: u32) -> Decimal {
-        Decimal {
-            lo: lo,
-            mid: mid,
-            hi: hi,
-            flags: flags(negative, scale),
-        }
-    }
-
-    /// Returns a `Decimal` using the instances constituent parts.
-    ///
-    /// # Arguments
-    ///
-    /// * `lo` - The low 32 bits of a 96-bit integer.
-    /// * `mid` - The middle 32 bits of a 96-bit integer.
-    /// * `hi` - The high 32 bits of a 96-bit integer.
-    /// * `negative` - `true` to indicate a negative number.
-    /// * `scale` - A power of 10 ranging from 0 to 28.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rust_decimal::Decimal;
-    ///
-    /// let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
-    /// assert_eq!(pi.to_string(), "3.1415926535897932384626433832");
-    /// ```
-    #[cfg(not(feature = "const_fn"))]
-    pub fn from_parts(lo: u32, mid: u32, hi: u32, negative: bool, scale: u32) -> Decimal {
         Decimal {
             lo: lo,
             mid: mid,
@@ -289,24 +239,7 @@ impl Decimal {
     /// assert_eq!(num.scale(), 3u32);
     /// ```
     #[inline]
-    #[cfg(feature = "const_fn")]
     pub const fn scale(&self) -> u32 {
-        ((self.flags & SCALE_MASK) >> SCALE_SHIFT) as u32
-    }
-
-    /// Returns the scale of the decimal number, otherwise known as `e`.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rust_decimal::Decimal;
-    ///
-    /// let num = Decimal::new(1234, 3);
-    /// assert_eq!(num.scale(), 3u32);
-    /// ```
-    #[inline]
-    #[cfg(not(feature = "const_fn"))]
-    pub fn scale(&self) -> u32 {
         ((self.flags & SCALE_MASK) >> SCALE_SHIFT) as u32
     }
 
@@ -363,7 +296,6 @@ impl Decimal {
     /// * Bytes 5-8: lo portion of `m`
     /// * Bytes 9-12: mid portion of `m`
     /// * Bytes 13-16: high portion of `m`
-    #[cfg(feature = "const_fn")]
     pub const fn serialize(&self) -> [u8; 16] {
         [
             (self.flags & U8_MASK) as u8,
@@ -385,35 +317,6 @@ impl Decimal {
         ]
     }
 
-    /// Returns a serialized version of the decimal number.
-    /// The resulting byte array will have the following representation:
-    ///
-    /// * Bytes 1-4: flags
-    /// * Bytes 5-8: lo portion of `m`
-    /// * Bytes 9-12: mid portion of `m`
-    /// * Bytes 13-16: high portion of `m`
-    #[cfg(not(feature = "const_fn"))]
-    pub fn serialize(&self) -> [u8; 16] {
-        [
-            (self.flags & U8_MASK) as u8,
-            ((self.flags >> 8) & U8_MASK) as u8,
-            ((self.flags >> 16) & U8_MASK) as u8,
-            ((self.flags >> 24) & U8_MASK) as u8,
-            (self.lo & U8_MASK) as u8,
-            ((self.lo >> 8) & U8_MASK) as u8,
-            ((self.lo >> 16) & U8_MASK) as u8,
-            ((self.lo >> 24) & U8_MASK) as u8,
-            (self.mid & U8_MASK) as u8,
-            ((self.mid >> 8) & U8_MASK) as u8,
-            ((self.mid >> 16) & U8_MASK) as u8,
-            ((self.mid >> 24) & U8_MASK) as u8,
-            (self.hi & U8_MASK) as u8,
-            ((self.hi >> 8) & U8_MASK) as u8,
-            ((self.hi >> 16) & U8_MASK) as u8,
-            ((self.hi >> 24) & U8_MASK) as u8,
-        ]
-    }
-
     /// Deserializes the given bytes into a decimal number.
     /// The deserialized byte representation must be 16 bytes and adhere to the followign convention:
     ///
@@ -421,25 +324,7 @@ impl Decimal {
     /// * Bytes 5-8: lo portion of `m`
     /// * Bytes 9-12: mid portion of `m`
     /// * Bytes 13-16: high portion of `m`
-    #[cfg(feature = "const_fn")]
     pub const fn deserialize(bytes: [u8; 16]) -> Decimal {
-        Decimal {
-            flags: (bytes[0] as u32) | (bytes[1] as u32) << 8 | (bytes[2] as u32) << 16 | (bytes[3] as u32) << 24,
-            lo: (bytes[4] as u32) | (bytes[5] as u32) << 8 | (bytes[6] as u32) << 16 | (bytes[7] as u32) << 24,
-            mid: (bytes[8] as u32) | (bytes[9] as u32) << 8 | (bytes[10] as u32) << 16 | (bytes[11] as u32) << 24,
-            hi: (bytes[12] as u32) | (bytes[13] as u32) << 8 | (bytes[14] as u32) << 16 | (bytes[15] as u32) << 24,
-        }
-    }
-
-    /// Deserializes the given bytes into a decimal number.
-    /// The deserialized byte representation must be 16 bytes and adhere to the followign convention:
-    ///
-    /// * Bytes 1-4: flags
-    /// * Bytes 5-8: lo portion of `m`
-    /// * Bytes 9-12: mid portion of `m`
-    /// * Bytes 13-16: high portion of `m`
-    #[cfg(not(feature = "const_fn"))]
-    pub fn deserialize(bytes: [u8; 16]) -> Decimal {
         Decimal {
             flags: (bytes[0] as u32) | (bytes[1] as u32) << 8 | (bytes[2] as u32) << 16 | (bytes[3] as u32) << 24,
             lo: (bytes[4] as u32) | (bytes[5] as u32) << 8 | (bytes[6] as u32) << 16 | (bytes[7] as u32) << 24,
@@ -462,54 +347,24 @@ impl Decimal {
 
     /// Returns `true` if the decimal is negative.
     #[inline(always)]
-    #[cfg(feature = "const_fn")]
     pub const fn is_sign_negative(&self) -> bool {
         self.flags & SIGN_MASK > 0
     }
 
-    /// Returns `true` if the decimal is negative.
-    #[inline(always)]
-    #[cfg(not(feature = "const_fn"))]
-    pub fn is_sign_negative(&self) -> bool {
-        self.flags & SIGN_MASK > 0
-    }
-
     /// Returns `true` if the decimal is positive.
     #[inline(always)]
-    #[cfg(feature = "const_fn")]
     pub const fn is_sign_positive(&self) -> bool {
         self.flags & SIGN_MASK == 0
     }
 
-    /// Returns `true` if the decimal is positive.
-    #[inline(always)]
-    #[cfg(not(feature = "const_fn"))]
-    pub fn is_sign_positive(&self) -> bool {
-        self.flags & SIGN_MASK == 0
-    }
-
     /// Returns the minimum possible number that `Decimal` can represent.
-    #[cfg(feature = "const_fn")]
     pub const fn min_value() -> Decimal {
         MIN
     }
 
-    /// Returns the minimum possible number that `Decimal` can represent.
-    #[cfg(not(feature = "const_fn"))]
-    pub fn min_value() -> Decimal {
-        *MIN
-    }
-
     /// Returns the maximum possible number that `Decimal` can represent.
-    #[cfg(feature = "const_fn")]
     pub const fn max_value() -> Decimal {
         MAX
-    }
-
-    /// Returns the maximum possible number that `Decimal` can represent.
-    #[cfg(not(feature = "const_fn"))]
-    pub fn max_value() -> Decimal {
-        *MAX
     }
 
     /// Returns a new `Decimal` integral with no fractional portion.
@@ -867,9 +722,10 @@ impl Decimal {
     ///
     /// let pi = Decimal::from_str("3.1415926535897932384626433832").unwrap();
     /// assert_eq!(format!("{:?}", pi), "3.1415926535897932384626433832");
-    /// assert_eq!(format!("{:?}", pi.unpack()), "UnpackedDecimal { is_negative: false, scale: 28, hi: 1703060790, mid: 185874565, lo: 1102470952 }");
+    /// assert_eq!(format!("{:?}", pi.unpack()), "UnpackedDecimal { \
+    ///     is_negative: false, scale: 28, hi: 1703060790, mid: 185874565, lo: 1102470952 \
+    /// }");
     /// ```
-    #[cfg(feature = "const_fn")]
     pub const fn unpack(&self) -> UnpackedDecimal {
         UnpackedDecimal {
             is_negative: self.is_sign_negative(),
@@ -899,16 +755,6 @@ impl Decimal {
     ///     is_negative: false, scale: 28, hi: 1703060790, mid: 185874565, lo: 1102470952 \
     /// }");
     /// ```
-    #[cfg(not(feature = "const_fn"))]
-    pub fn unpack(&self) -> UnpackedDecimal {
-        UnpackedDecimal {
-            is_negative: self.is_sign_negative(),
-            scale: self.scale(),
-            hi: self.hi,
-            lo: self.lo,
-            mid: self.mid,
-        }
-    }
 
     #[inline(always)]
     pub(crate) fn mantissa_array3(&self) -> [u32; 3] {
@@ -1476,7 +1322,12 @@ impl Decimal {
         // Round if necessary. This is for semantic correctness, but could feasibly be removed for
         // performance improvements.
         if quotient_scale > initial_scale {
-            let mut working = [working_remainder[0], working_remainder[1], working_remainder[2], working_remainder[3]];
+            let mut working = [
+                working_remainder[0],
+                working_remainder[1],
+                working_remainder[2],
+                working_remainder[3],
+            ];
             while quotient_scale > initial_scale {
                 if div_by_u32(&mut working, 10) > 0 {
                     break;
@@ -1508,14 +1359,7 @@ enum DivResult {
 }
 
 #[inline]
-#[cfg(feature = "const_fn")]
 const fn flags(neg: bool, scale: u32) -> u32 {
-    (scale << SCALE_SHIFT) | ((neg as u32) << SIGN_SHIFT)
-}
-
-#[inline]
-#[cfg(not(feature = "const_fn"))]
-fn flags(neg: bool, scale: u32) -> u32 {
     (scale << SCALE_SHIFT) | ((neg as u32) << SIGN_SHIFT)
 }
 
@@ -2731,7 +2575,6 @@ impl<'a> DivAssign<&'a Decimal> for &'a mut Decimal {
         Decimal::div_assign(*self, *other)
     }
 }
-
 
 forward_all_binop!(impl Rem for Decimal, rem);
 

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -6,14 +6,10 @@ use crate::Decimal;
 
 use postgres::{to_sql_checked, types::*};
 
-#[cfg(not(feature = "const_fn"))]
-use lazy_static::lazy_static;
-
 use std::{error, fmt, io::Cursor, result::*};
 
 use crate::decimal::{div_by_u32, is_all_zero, mul_by_u32};
 
-#[cfg(feature = "const_fn")]
 const DECIMALS: [Decimal; 15] = [
     Decimal::from_parts(1, 0, 0, false, 28),
     Decimal::from_parts(1, 0, 0, false, 24),
@@ -43,30 +39,6 @@ const DECIMALS: [Decimal; 15] = [
     Decimal::from_parts(2701131776, 466537709, 54210, false, 0),
     Decimal::from_parts(268435456, 1042612833, 542101086, false, 0),
 ];
-
-#[cfg(not(feature = "const_fn"))]
-lazy_static! {
-
-    // When procedural macro's are stabablized
-    //  this will look MUCH better
-    static ref DECIMALS: [Decimal; 15] = [
-        Decimal::new(1, 28),
-        Decimal::new(1, 24),
-        Decimal::new(1, 20),
-        Decimal::new(1, 16),
-        Decimal::new(1, 12),
-        Decimal::new(1, 8),
-        Decimal::new(1, 4),
-        Decimal::new(1, 0),
-        Decimal::new(10000, 0),
-        Decimal::new(100000000, 0),
-        Decimal::new(1000000000000, 0),
-        Decimal::new(10000000000000000, 0),
-        Decimal::from_parts(1661992960, 1808227885, 5, false, 0),
-        Decimal::from_parts(2701131776, 466537709, 54210, false, 0),
-        Decimal::from_parts(268435456, 1042612833, 542101086, false, 0),
-    ];
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct InvalidDecimal;
@@ -380,9 +352,7 @@ mod test {
 
     #[test]
     fn numeric_overflow() {
-        let tests = [
-            (4, 4, "3950.1234"),
-        ];
+        let tests = [(4, 4, "3950.1234")];
         let conn = match Connection::connect("postgres://postgres@localhost", TlsMode::None) {
             Ok(x) => x,
             Err(err) => panic!("{:#?}", err),
@@ -393,10 +363,13 @@ mod test {
                 Err(err) => panic!("{:#?}", err),
             };
             match stmt.query(&[]) {
-                Ok(_) => panic!("Expected numeric overflow for {}::NUMERIC({}, {})", sent, precision, scale),
+                Ok(_) => panic!(
+                    "Expected numeric overflow for {}::NUMERIC({}, {})",
+                    sent, precision, scale
+                ),
                 Err(err) => {
                     assert_eq!("22003", err.code().unwrap().code(), "Unexpected error code");
-                },
+                }
             };
         }
     }


### PR DESCRIPTION
Details:

- Removes `const_fn` and `lazy_static` features from feature list.
- Defaults all branches of conditional compilation with `const_fn` route.
- Removes `lazy_static` dependency.

Fixes https://github.com/paupino/rust-decimal/issues/186.