### PR TITLE
quick and dirty change of using `postgres` library to `tokio-postgres`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ license = "MIT"
 travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 
 [dependencies]
-num = "0.2"
 byteorder = "1.3"
-postgres = { version = "0.15", optional = true }
+float-cmp = "0.5.0"
+num = "0.2"
 serde = { version = "1.0", optional = true }
+tokio-postgres = { version = "0.4.0-rc.2", optional = true }
 
 [dev-dependencies]
 rand = "0.6"
@@ -30,6 +31,8 @@ serde_derive = "1.0"
 
 [features]
 default = ["serde"]
+
+postgres = ["tokio-postgres"]
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 [dependencies]
 byteorder = "1.3"
 float-cmp = "0.5.0"
+futures = { version = "0.1", optional = true }
 num = "0.2"
 serde = { version = "1.0", optional = true }
+tokio = { version = "0.1.21", optional = true }
 tokio-postgres = { version = "0.4.0-rc.2", optional = true }
 
 [dev-dependencies]
@@ -32,7 +34,7 @@ serde_derive = "1.0"
 [features]
 default = ["serde"]
 
-postgres = ["tokio-postgres"]
+postgres = ["futures", "tokio", "tokio-postgres"]
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]

--- a/benches/lib_benches.rs
+++ b/benches/lib_benches.rs
@@ -129,7 +129,7 @@ fn iterator_sum(b: &mut ::test::Bencher) {
 #[cfg(feature = "postgres")]
 #[bench]
 fn to_from_sql(b: &mut ::test::Bencher) {
-    use postgres::types::{FromSql, Kind, ToSql, Type};
+    use tokio_postgres::types::{FromSql, Kind, ToSql, Type};
 
     let samples_strs = &[
         "3950.123456",

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -181,9 +181,9 @@ impl Decimal {
     /// ```
     pub const fn from_parts(lo: u32, mid: u32, hi: u32, negative: bool, scale: u32) -> Decimal {
         Decimal {
-            lo: lo,
-            mid: mid,
-            hi: hi,
+            lo,
+            mid,
+            hi,
             flags: flags(negative, scale),
         }
     }
@@ -207,8 +207,8 @@ impl Decimal {
         let err = Error::new("Failed to parse");
         let mut split = value.splitn(2, 'e');
 
-        let base = split.next().ok_or(err.clone())?;
-        let mut scale = split.next().ok_or(err.clone())?.to_string();
+        let base = split.next().ok_or_else(|| err.clone())?;
+        let mut scale = split.next().ok_or_else(|| err.clone())?.to_string();
 
         let mut ret = Decimal::from_str(base)?;
 

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -4,7 +4,7 @@ use num::Zero;
 
 use crate::Decimal;
 
-use postgres::{to_sql_checked, types::*};
+use tokio_postgres::{to_sql_checked, types::*};
 
 use std::{error, fmt, io::Cursor, result::*};
 
@@ -55,7 +55,7 @@ impl error::Error for InvalidDecimal {
     }
 }
 
-impl FromSql for Decimal {
+impl<'a> FromSql<'a> for Decimal {
     // Decimals are represented as follows:
     // Header:
     //  u16 numGroups
@@ -155,7 +155,7 @@ impl FromSql for Decimal {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match *ty {
+        match ty {
             NUMERIC => true,
             _ => false,
         }
@@ -219,7 +219,7 @@ impl ToSql for Decimal {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match *ty {
+        match ty {
             NUMERIC => true,
             _ => false,
         }

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1308,7 +1308,7 @@ fn it_panics_when_scale_too_large() {
 #[cfg(feature = "postgres")]
 #[test]
 fn to_from_sql() {
-    use postgres::types::{FromSql, Kind, ToSql, Type};
+    use tokio_postgres::types::{FromSql, Kind, ToSql, Type};
 
     let tests = &[
         "3950.123456",
@@ -1333,7 +1333,7 @@ fn to_from_sql() {
         "-18446744073709551615",
     ];
 
-    let t = Type::_new("".into(), 0, Kind::Simple, "".into());
+    let t = Type::from_oid(0).unwrap();
 
     for test in tests {
         let input = Decimal::from_str(test).unwrap();

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1,14 +1,13 @@
-extern crate num;
-extern crate rust_decimal;
-
+use float_cmp::*;
 use num::{ToPrimitive, Zero};
-
 use rust_decimal::{Decimal, RoundingStrategy};
 
 use std::{
     cmp::{Ordering, Ordering::*},
     str::FromStr,
 };
+
+// Since comparison of floating point numbers is considered a bad practice by clippy, we are using an implementation (`float_cmp`) of its suggested link (https://www.floating-point-gui.de/errors/comparison/) to see if floating point numbers are similar enough to be considered equal.
 
 // Parsing
 
@@ -1035,17 +1034,36 @@ fn it_can_go_from_and_into() {
 
 #[test]
 fn it_converts_to_f64() {
-    assert_eq!(5f64, Decimal::from_str("5").unwrap().to_f64().unwrap());
-    assert_eq!(-5f64, Decimal::from_str("-5").unwrap().to_f64().unwrap());
-    assert_eq!(0.1f64, Decimal::from_str("0.1").unwrap().to_f64().unwrap());
-    assert_eq!(
+    assert!(approx_eq!(
+        f64,
+        5f64,
+        Decimal::from_str("5").unwrap().to_f64().unwrap(),
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
+        -5f64,
+        Decimal::from_str("-5").unwrap().to_f64().unwrap(),
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
+        0.1f64,
+        Decimal::from_str("0.1").unwrap().to_f64().unwrap(),
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
         0.25e-11f64,
-        Decimal::from_str("0.0000000000025").unwrap().to_f64().unwrap()
-    );
-    assert_eq!(
+        Decimal::from_str("0.0000000000025").unwrap().to_f64().unwrap(),
+        ulps = 2
+    ));
+    assert!(approx_eq!(
+        f64,
         1e6f64,
-        Decimal::from_str("1000000.0000000000025").unwrap().to_f64().unwrap()
-    );
+        Decimal::from_str("1000000.0000000000025").unwrap().to_f64().unwrap(),
+        ulps = 2
+    ));
 }
 
 #[test]
@@ -1084,13 +1102,22 @@ fn it_converts_from_f32() {
     assert_eq!("0.12345", from_f32(0.12345f32).unwrap().to_string());
     assert_eq!(
         "0.12345678",
-        from_f32(0.1234567800123456789012345678f32).unwrap().to_string()
+        from_f32(0.123_456_780_012_345_678_901_234_567_8f32)
+            .unwrap()
+            .to_string()
     );
     assert_eq!(
         "0.12345679",
-        from_f32(0.12345678901234567890123456789f32).unwrap().to_string()
+        from_f32(0.123_456_789_012_345_678_901_234_567_89f32)
+            .unwrap()
+            .to_string()
     );
-    assert_eq!("0", from_f32(0.00000000000000000000000000001f32).unwrap().to_string());
+    assert_eq!(
+        "0",
+        from_f32(0.000_000_000_000_000_000_000_000_000_01f32)
+            .unwrap()
+            .to_string()
+    );
 
     assert!(from_f32(std::f32::NAN).is_none());
     assert!(from_f32(std::f32::INFINITY).is_none());
@@ -1111,13 +1138,22 @@ fn it_converts_from_f64() {
     assert_eq!("0.12345", from_f64(0.12345f64).unwrap().to_string());
     assert_eq!(
         "0.1234567890123456",
-        from_f64(0.1234567890123456089012345678f64).unwrap().to_string()
+        from_f64(0.123_456_789_012_345_608_901_234_567_8f64)
+            .unwrap()
+            .to_string()
     );
     assert_eq!(
         "0.1234567890123457",
-        from_f64(0.12345678901234567890123456789f64).unwrap().to_string()
+        from_f64(0.123_456_789_012_345_678_901_234_567_89f64)
+            .unwrap()
+            .to_string()
     );
-    assert_eq!("0", from_f64(0.00000000000000000000000000001f64).unwrap().to_string());
+    assert_eq!(
+        "0",
+        from_f64(0.000_000_000_000_000_000_000_000_000_01f64)
+            .unwrap()
+            .to_string()
+    );
 
     assert!(from_f64(std::f64::NAN).is_none());
     assert!(from_f64(std::f64::INFINITY).is_none());
@@ -1244,7 +1280,7 @@ fn it_can_reject_invalid_formats() {
 
 #[test]
 fn it_can_parse_individual_parts() {
-    let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
+    let pi = Decimal::from_parts(1_102_470_952, 185_874_565, 1_703_060_790, false, 28);
     assert_eq!(pi.to_string(), "3.1415926535897932384626433832");
 }
 


### PR DESCRIPTION
I've done the minimal work of making `rust-decimal` compatible with the latest release candidate of tokio-postgres (v0.4.0-rc2 as of now).

There's still compilation warnings from clippy, but everything seems to work.