### PR TITLE
Upgrade to rust-postgres 0.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 [dependencies]
 num = "0.2"
 byteorder = "1.3"
-postgres = { version = "0.16.0-rc.1", optional = true }
+postgres = { git = "https://github.com/pimeys/rust-postgres", branch = "std-futures", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 [dependencies]
 num = "0.2"
 byteorder = "1.3"
-postgres = { version = "0.15", optional = true }
+postgres = { version = "0.16.0-rc.1", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1272,7 +1272,7 @@ fn it_panics_when_scale_too_large() {
 #[cfg(feature = "postgres")]
 #[test]
 fn to_from_sql() {
-    use postgres::types::{FromSql, Kind, ToSql, Type};
+    use postgres::types::{FromSql, ToSql, Type};
 
     let tests = &[
         "3950.123456",
@@ -1297,13 +1297,11 @@ fn to_from_sql() {
         "-18446744073709551615",
     ];
 
-    let t = Type::_new("".into(), 0, Kind::Simple, "".into());
-
     for test in tests {
         let input = Decimal::from_str(test).unwrap();
         let mut vec = Vec::<u8>::new();
-        input.to_sql(&t, &mut vec).unwrap();
-        let output = Decimal::from_sql(&t, &vec).unwrap();
+        input.to_sql(&Type::NUMERIC, &mut vec).unwrap();
+        let output = Decimal::from_sql(&Type::NUMERIC, &vec).unwrap();
 
         assert_eq!(input, output);
     }


### PR DESCRIPTION
An upgrade path to postgres 0.16.0 is a bit bumpy and we're using it (and soon the async version) already, so we needed to upgrade rust-decimal before postgres was stabilized... Don't know really when do you want to merge this and it is a breaking change for the users.