### PR TITLE
Upgrades rand due to deprecated features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ postgres = { version = "0.15", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.7"
 serde_json = "1.0"
 serde_derive = "1.0"
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2017,7 +2017,7 @@ impl FromStr for Decimal {
         while len > 0 {
             let b = bytes[offset];
             match b {
-                b'0'...b'9' => {
+                b'0'..=b'9' => {
                     coeff.push(u32::from(b - b'0'));
                     offset += 1;
                     len -= 1;
@@ -2029,7 +2029,7 @@ impl FromStr for Decimal {
                             // We only need to look at the next significant digit
                             let next_byte = bytes[offset];
                             match next_byte {
-                                b'0'...b'9' => {
+                                b'0'..=b'9' => {
                                     let digit = u32::from(next_byte - b'0');
                                     if digit >= 5 {
                                         let mut index = coeff.len() - 1;

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -109,7 +109,7 @@ impl FromSql for Decimal {
     //   result = result + 5600 * 0.00000001;
     //
 
-    fn from_sql(_: &Type, raw: &[u8]) -> Result<Decimal, Box<error::Error + 'static + Sync + Send>> {
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<Decimal, Box<dyn error::Error + 'static + Sync + Send>> {
         let mut raw = Cursor::new(raw);
         let num_groups = raw.read_u16::<BigEndian>()?;
         let weight = raw.read_i16::<BigEndian>()?; // 10000^weight
@@ -163,7 +163,7 @@ impl FromSql for Decimal {
 }
 
 impl ToSql for Decimal {
-    fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<error::Error + 'static + Sync + Send>> {
+    fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<dyn error::Error + 'static + Sync + Send>> {
         // If it's zero we can short cut with a u64
         if self.is_zero() {
             out.write_u64::<BigEndian>(0)?;


### PR DESCRIPTION
Upgrades `rand` from `0.6` to `0.7` to address recent build issues.
Also updates some deprecated language features towards the new equivalent.