### PR TITLE
Support tokio-postgres 0.5.0 and async/await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,16 +22,16 @@ num = "0.2"
 byteorder = "1.3"
 float-cmp = "0.5.0"
 diesel = { version = "1.4", default-features = false, features = ["postgres"], optional = true }
-tokio-postgres = { version = "0.5.0-alpha.1", optional = true }
-bytes = { version = "0.4" }
+tokio-postgres = { version = "0.5.0-alpha.2", optional = true }
+bytes = { version = "0.5" }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.7"
 serde_json = "1.0"
 serde_derive = "1.0"
-tokio = { version = "0.2.0-alpha.6" }
-futures-preview = { version = "0.3.0-alpha.19" }
+tokio = { version = "0.2", features = ["rt-threaded", "test-util", "macros"] }
+futures = "0.3"
 
 [features]
 default = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,22 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 [dependencies]
 num = "0.2"
 byteorder = "1.3"
+float-cmp = "0.5.0"
 diesel = { version = "1.4", default-features = false, features = ["postgres"], optional = true }
-postgres = { version = "0.15", optional = true }
+tokio-postgres = { version = "0.5.0-alpha.1", optional = true }
+bytes = { version = "0.4" }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.7"
 serde_json = "1.0"
 serde_derive = "1.0"
+tokio = { version = "0.2.0-alpha.6" }
+futures-preview = { version = "0.3.0-alpha.19" }
 
 [features]
 default = ["serde"]
+postgres = ["tokio-postgres"]
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -505,16 +505,16 @@ mod postgres {
             out.reserve(8 + num_digits * 2);
 
             // Number of groups
-            out.put_u16_be(num_digits.try_into().unwrap());
+            out.put_u16(num_digits.try_into().unwrap());
             // Weight of first group
-            out.put_i16_be(weight);
+            out.put_i16(weight);
             // Sign
-            out.put_u16_be(if neg { 0x4000 } else { 0x0000 });
+            out.put_u16(if neg { 0x4000 } else { 0x0000 });
             // DScale
-            out.put_u16_be(scale);
+            out.put_u16(scale);
             // Now process the number
             for digit in digits[0..num_digits].iter() {
-                out.put_i16_be(*digit);
+                out.put_i16(*digit);
             }
 
             Ok(IsNull::No)

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -403,11 +403,12 @@ mod diesel {
 mod postgres {
     use super::*;
 
-    use ::byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
-    use ::postgres::{to_sql_checked, types::*};
+    use ::byteorder::{BigEndian, ReadBytesExt};
+    use ::bytes::{BytesMut, BufMut};
+    use ::tokio_postgres::types::*;
     use ::std::io::Cursor;
 
-    impl FromSql for Decimal {
+    impl<'a> FromSql<'a> for Decimal {
         // Decimals are represented as follows:
         // Header:
         //  u16 numGroups
@@ -486,15 +487,12 @@ mod postgres {
         }
 
         fn accepts(ty: &Type) -> bool {
-            match *ty {
-                NUMERIC => true,
-                _ => false,
-            }
+            ty.name() == "numeric"
         }
     }
 
     impl ToSql for Decimal {
-        fn to_sql(&self, _: &Type, out: &mut Vec<u8>) -> Result<IsNull, Box<dyn error::Error + 'static + Sync + Send>> {
+        fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn error::Error + 'static + Sync + Send>> {
             let PostgresDecimal {
                 neg,
                 weight,
@@ -504,27 +502,26 @@ mod postgres {
 
             let num_digits = digits.len();
 
+            out.reserve(8 + num_digits * 2);
+
             // Number of groups
-            out.write_u16::<BigEndian>(num_digits.try_into().unwrap())?;
+            out.put_u16_be(num_digits.try_into().unwrap());
             // Weight of first group
-            out.write_i16::<BigEndian>(weight)?;
+            out.put_i16_be(weight);
             // Sign
-            out.write_u16::<BigEndian>(if neg { 0x4000 } else { 0x0000 })?;
+            out.put_u16_be(if neg { 0x4000 } else { 0x0000 });
             // DScale
-            out.write_u16::<BigEndian>(scale)?;
+            out.put_u16_be(scale);
             // Now process the number
             for digit in digits[0..num_digits].iter() {
-                out.write_i16::<BigEndian>(*digit)?;
+                out.put_i16_be(*digit);
             }
 
             Ok(IsNull::No)
         }
 
         fn accepts(ty: &Type) -> bool {
-            match *ty {
-                NUMERIC => true,
-                _ => false,
-            }
+            ty.name() == "numeric"
         }
 
         to_sql_checked!();
@@ -534,7 +531,8 @@ mod postgres {
     mod test {
         use super::*;
 
-        use ::postgres::{Connection, TlsMode};
+        use futures::future::FutureExt;
+        use ::tokio_postgres::{connect, NoTls};
 
         use std::str::FromStr;
 
@@ -594,85 +592,68 @@ mod postgres {
             assert_eq!(&expected_decimals[..], &DECIMALS[..]);
         }
 
-        #[test]
-        fn test_null() {
-            let conn = match Connection::connect("postgres://postgres@localhost", TlsMode::None) {
-                Ok(x) => x,
-                Err(err) => panic!("{:#?}", err),
-            };
+        #[tokio::test]
+        async fn test_null() {
+            let (client, connection) = connect("postgres://postgres@localhost", NoTls).await.unwrap();
+            let connection = connection.map(|e| e.unwrap());
+            tokio::spawn(connection);
 
             // Test NULL
-            let stmt = match conn.prepare(&"SELECT NULL::numeric") {
-                Ok(x) => x,
-                Err(err) => panic!("{:#?}", err),
-            };
-            let result: Option<Decimal> = match stmt.query(&[]) {
-                Ok(x) => x.iter().next().unwrap().get(0),
-                Err(err) => panic!("{:#?}", err),
-            };
+            let statement = client.prepare(&"SELECT NULL::numeric").await.unwrap();
+            let rows = client.query(&statement, &[]).await.unwrap();
+            let result: Option<Decimal> = rows.iter().next().unwrap().get(0);
+
             assert_eq!(None, result);
         }
 
-        #[test]
-        fn read_numeric_type() {
-            let conn = match Connection::connect("postgres://postgres@localhost", TlsMode::None) {
-                Ok(x) => x,
-                Err(err) => panic!("{:#?}", err),
-            };
+        #[tokio::test]
+        async fn read_numeric_type() {
+            let (client, connection) = connect("postgres://postgres@localhost", NoTls).await.unwrap();
+            let connection = connection.map(|e| e.unwrap());
+            tokio::spawn(connection);
+
             for &(precision, scale, sent, expected) in TEST_DECIMALS.iter() {
-                let stmt = match conn.prepare(&*format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale)) {
-                    Ok(x) => x,
-                    Err(err) => panic!("{:#?}", err),
-                };
-                let result: Decimal = match stmt.query(&[]) {
-                    Ok(x) => x.iter().next().unwrap().get(0),
-                    Err(err) => panic!("{:#?}", err),
-                };
+                let statement = client.prepare(&*format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale)).await.unwrap();
+                let rows = client.query(&statement, &[]).await.unwrap();
+                let result: Decimal = rows.iter().next().unwrap().get(0);
+
                 assert_eq!(expected, result.to_string(), "NUMERIC({}, {})", precision, scale);
             }
         }
 
-        #[test]
-        fn write_numeric_type() {
-            let conn = match Connection::connect("postgres://postgres@localhost", TlsMode::None) {
-                Ok(x) => x,
-                Err(err) => panic!("{:#?}", err),
-            };
+        #[tokio::test]
+        async fn write_numeric_type() {
+            let (client, connection) = connect("postgres://postgres@localhost", NoTls).await.unwrap();
+            let connection = connection.map(|e| e.unwrap());
+            tokio::spawn(connection);
+
             for &(precision, scale, sent, expected) in TEST_DECIMALS.iter() {
-                let stmt = match conn.prepare(&*format!("SELECT $1::NUMERIC({}, {})", precision, scale)) {
-                    Ok(x) => x,
-                    Err(err) => panic!("{:#?}", err),
-                };
+                let statement = client.prepare(&*format!("SELECT $1::NUMERIC({}, {})", precision, scale)).await.unwrap();
                 let number = Decimal::from_str(sent).unwrap();
-                let result: Decimal = match stmt.query(&[&number]) {
-                    Ok(x) => x.iter().next().unwrap().get(0),
-                    Err(err) => panic!("{:#?}", err),
-                };
+                let rows = client.query(&statement, &[&number]).await.unwrap();
+                let result: Decimal = rows.iter().next().unwrap().get(0);
+
                 assert_eq!(expected, result.to_string(), "NUMERIC({}, {})", precision, scale);
             }
         }
 
-        #[test]
-        fn numeric_overflow() {
+        #[tokio::test]
+        async fn numeric_overflow() {
             let tests = [(4, 4, "3950.1234")];
-            let conn = match Connection::connect("postgres://postgres@localhost", TlsMode::None) {
-                Ok(x) => x,
-                Err(err) => panic!("{:#?}", err),
-            };
+            let (client, connection) = connect("postgres://postgres@localhost", NoTls).await.unwrap();
+            let connection = connection.map(|e| e.unwrap());
+            tokio::spawn(connection);
+
             for &(precision, scale, sent) in tests.iter() {
-                let stmt = match conn.prepare(&*format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale)) {
-                    Ok(x) => x,
-                    Err(err) => panic!("{:#?}", err),
-                };
-                match stmt.query(&[]) {
+                let statement = client.prepare(&*format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale)).await.unwrap();
+
+                match client.query(&statement, &[]).await {
                     Ok(_) => panic!(
                         "Expected numeric overflow for {}::NUMERIC({}, {})",
                         sent, precision, scale
                     ),
-                    Err(err) => {
-                        assert_eq!("22003", err.code().unwrap().code(), "Unexpected error code");
-                    }
-                };
+                    Err(err) => assert_eq!("22003", err.code().unwrap().code(), "Unexpected error code"),
+                }
             }
         }
     }

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1295,7 +1295,8 @@ fn it_panics_when_scale_too_large() {
 #[cfg(feature = "postgres")]
 #[test]
 fn to_from_sql() {
-    use postgres::types::{FromSql, Kind, ToSql, Type};
+    use tokio_postgres::types::{FromSql, ToSql, Type, Kind};
+    use bytes::BytesMut;
 
     let tests = &[
         "3950.123456",
@@ -1320,13 +1321,13 @@ fn to_from_sql() {
         "-18446744073709551615",
     ];
 
-    let t = Type::_new("".into(), 0, Kind::Simple, "".into());
+    let t = Type::new("".into(), 0, Kind::Simple, "".into());
 
     for test in tests {
         let input = Decimal::from_str(test).unwrap();
-        let mut vec = Vec::<u8>::new();
-        input.to_sql(&t, &mut vec).unwrap();
-        let output = Decimal::from_sql(&t, &vec).unwrap();
+        let mut bytes = BytesMut::new();
+        input.to_sql(&t, &mut bytes).unwrap();
+        let output = Decimal::from_sql(&t, &bytes).unwrap();
 
         assert_eq!(input, output);
     }


### PR DESCRIPTION
Async/await is soon stable and we should support the async/await version of tokio-postgres.

This PR was a bit more involved due to tokio-postgres now using `bytes` in the `to_sql` function.