### PR TITLE
Upgrade Postgres to 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,9 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 [dependencies]
 num = "0.2"
 byteorder = "1.3"
+bytes = "0.5"
 diesel = { version = "1.4", default-features = false, features = ["postgres"], optional = true }
-postgres = { version = "0.15", optional = true }
+postgres = { version = "0.17", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,19 @@ byteorder = "1.3"
 bytes = "0.5"
 diesel = { version = "1.4", default-features = false, features = ["postgres"], optional = true }
 postgres = { version = "0.17", optional = true }
+tokio-postgres = { version = "0.5", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
 rand = "0.7"
 serde_json = "1.0"
 serde_derive = "1.0"
+tokio = { version = "0.2", features = ["rt-threaded", "test-util", "macros"] }
+futures = "0.3"
 
 [features]
 default = ["serde"]
+tokio-pg = ["postgres", "tokio-postgres"]
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]

--- a/VERSION.md
+++ b/VERSION.md
@@ -4,6 +4,8 @@
 
 * Update to Postgres 0.17 and add async/await support
 
+Special thanks to @pimeys and @kaibyao!
+
 ## 1.0.3
 
 Updates dependencies to prevent build issues.

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,9 @@
 # Version History
 
+## 1.1.x
+
+* Update to Postgres 0.17 and add async/await support
+
 ## 1.0.3
 
 Updates dependencies to prevent build issues.

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -614,6 +614,7 @@ mod postgres {
         }
 
         #[tokio::test]
+        #[cfg(feature = "tokio-pg")]
         async fn async_test_null() {
             use ::tokio_postgres::connect;
             use ::futures::future::FutureExt;
@@ -645,6 +646,7 @@ mod postgres {
         }
 
         #[tokio::test]
+        #[cfg(feature = "tokio-pg")]
         async fn async_read_numeric_type() {
             use ::tokio_postgres::connect;
             use ::futures::future::FutureExt;
@@ -678,6 +680,7 @@ mod postgres {
         }
 
         #[tokio::test]
+        #[cfg(feature = "tokio-pg")]
         async fn async_write_numeric_type() {
             use ::tokio_postgres::connect;
             use ::futures::future::FutureExt;
@@ -717,6 +720,7 @@ mod postgres {
         }
 
         #[tokio::test]
+        #[cfg(feature = "tokio-pg")]
         async fn async_numeric_overflow() {
             use ::tokio_postgres::connect;
             use ::futures::future::FutureExt;

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1296,6 +1296,7 @@ fn it_panics_when_scale_too_large() {
 #[test]
 fn to_from_sql() {
     use postgres::types::{FromSql, Kind, ToSql, Type};
+    use bytes::BytesMut;
 
     let tests = &[
         "3950.123456",
@@ -1320,13 +1321,13 @@ fn to_from_sql() {
         "-18446744073709551615",
     ];
 
-    let t = Type::_new("".into(), 0, Kind::Simple, "".into());
+    let t = Type::new("".into(), 0, Kind::Simple, "".into());
 
     for test in tests {
         let input = Decimal::from_str(test).unwrap();
-        let mut vec = Vec::<u8>::new();
-        input.to_sql(&t, &mut vec).unwrap();
-        let output = Decimal::from_sql(&t, &vec).unwrap();
+        let mut bytes = BytesMut::new();
+        input.to_sql(&t, &mut bytes).unwrap();
+        let output = Decimal::from_sql(&t, &bytes).unwrap();
 
         assert_eq!(input, output);
     }


### PR DESCRIPTION
Upgraded Postgres to 0.17 as well as add tests for tokio-postgres support.

Closes #203, #198 and #196 