### PR TITLE
Remove std::error::Error providing the description and instead relying on Display

### DIFF
--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -41,15 +41,11 @@ pub struct InvalidDecimal;
 
 impl fmt::Display for InvalidDecimal {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.write_str(error::Error::description(self))
+        fmt.write_str("Invalid Decimal")
     }
 }
 
-impl error::Error for InvalidDecimal {
-    fn description(&self) -> &str {
-        "Invalid Decimal"
-    }
-}
+impl error::Error for InvalidDecimal {}
 
 struct PostgresDecimal<D> {
     neg: bool,


### PR DESCRIPTION
This removes the deprecation warning from compile time. Functionality stays the same.