### PR TITLE
implemented an optimized to_f64()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0"
 serde_derive = "1.0"
 tokio = { version = "0.2", features = ["rt-threaded", "test-util", "macros"] }
 futures = "0.3"
+float-cmp = "0.6"
 
 [features]
 default = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ serde_json = "1.0"
 serde_derive = "1.0"
 tokio = { version = "0.2", features = ["rt-threaded", "test-util", "macros"] }
 futures = "0.3"
-float-cmp = "0.6"
 
 [features]
 default = ["serde"]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -7,6 +7,8 @@ use std::{
     str::FromStr,
 };
 
+use float_cmp::approx_eq;
+
 // Parsing
 
 #[test]
@@ -1062,10 +1064,14 @@ fn it_converts_to_f64() {
     assert_eq!(5f64, Decimal::from_str("5").unwrap().to_f64().unwrap());
     assert_eq!(-5f64, Decimal::from_str("-5").unwrap().to_f64().unwrap());
     assert_eq!(0.1f64, Decimal::from_str("0.1").unwrap().to_f64().unwrap());
-    assert_eq!(
+    assert_eq!(0f64, Decimal::from_str("0.0").unwrap().to_f64().unwrap());
+    assert_eq!(0f64, Decimal::from_str("-0.0").unwrap().to_f64().unwrap());
+    assert!(approx_eq!(
+        f64,
         0.25e-11f64,
-        Decimal::from_str("0.0000000000025").unwrap().to_f64().unwrap()
-    );
+        Decimal::from_str("0.0000000000025").unwrap().to_f64().unwrap(),
+        ulps = 2
+    ));
     assert_eq!(
         1e6f64,
         Decimal::from_str("1000000.0000000000025").unwrap().to_f64().unwrap()

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -7,8 +7,6 @@ use std::{
     str::FromStr,
 };
 
-use float_cmp::approx_eq;
-
 // Parsing
 
 #[test]
@@ -1066,15 +1064,33 @@ fn it_converts_to_f64() {
     assert_eq!(0.1f64, Decimal::from_str("0.1").unwrap().to_f64().unwrap());
     assert_eq!(0f64, Decimal::from_str("0.0").unwrap().to_f64().unwrap());
     assert_eq!(0f64, Decimal::from_str("-0.0").unwrap().to_f64().unwrap());
-    assert!(approx_eq!(
-        f64,
+    assert_eq!(
         0.25e-11f64,
         Decimal::from_str("0.0000000000025").unwrap().to_f64().unwrap(),
-        ulps = 2
-    ));
+    );
     assert_eq!(
         1e6f64,
         Decimal::from_str("1000000.0000000000025").unwrap().to_f64().unwrap()
+    );
+    assert_eq!(
+        0.25e-25_f64,
+        Decimal::from_str("0.000000000000000000000000025")
+            .unwrap()
+            .to_f64()
+            .unwrap(),
+    );
+    assert_eq!(
+        2.1234567890123456789012345678_f64,
+        Decimal::from_str("2.1234567890123456789012345678")
+            .unwrap()
+            .to_f64()
+            .unwrap(),
+    );
+
+    assert_eq!(
+        None,
+        // Cannot be represented in an f64
+        Decimal::from_str("21234567890123456789012345678").unwrap().to_f64(),
     );
 }
 


### PR DESCRIPTION
This is a follow up of the issue here: https://github.com/paupino/rust-decimal/issues/234

I ended up implementing an alternative (IMHO simpler) idea. Hopefully the code is readable enough.

I thought about re-constructing the f64 from scratch using the Decimal's internal parts, but quickly ran into some questions that I'm not sure how to address. The gist is this:

We know a Decimal value is `sign * m / 10^e`, where m is a 96-bit integer, and e is at most 28, while an f64 value is `sign * m / 2^e`. This means we need to convert a base 10 exponent into a base 2 exponent.

So, we can rewrite the Decimal value `sign * m / 10^e` into `sign * (m / 5^e) / 2^e`. Let `m' = m / 5^e`. This `m'` will be the mantissa for the f64 value. The problem is `m` itself is not necessarily divisible by 5, the best we can do is approximate it with the integer that's closest to `m / 5^e`. So there's some loss of precision.

So, IMO, since we are losing precision here anyways, maybe it's worth it to simply use `f64` arithmetic to calculate the fractional part of the Decimal value directly, and add that to the integral part of the Decimal value. Hence, the alternative algorithm below.

This implementation breaks one of the test cases in `it_converts_to_f64` with the following output:
```
---- it_converts_to_f64 stdout ----
thread 'it_converts_to_f64' panicked at 'assertion failed: `(left == right)`
  left: `0.0000000000025`,
 right: `0.0000000000025000000000000007`', tests/decimal_tests.rs:1065:5
```

 The test case is originally doing exact floating number comparison between the LHS and RHS. I revised it to use approximate comparison through the `float-cmp` crate. This shows the `LHS` and `RHS` are less than 2 ULPS apart, which means they are less than 2 units of precision apart at their current exponent.

This may or may not be acceptable for you... I'm happy to consider other routes that can potentially avoid modifying this existing test case.