### PR TITLE
Add missing use statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Alternatively you can also use one of the Decimal number convenience functions:
 
 ```rust
 use rust_decimal::Decimal;
+use std::str::FromStr;
 
 // Using an integer followed by the decimal points
 let scaled = Decimal::new(202, 2); // 2.02


### PR DESCRIPTION
The README is missing a crucial use statement, without with the following line would throw an error:

```
error[E0599]: no function or associated item named `from_str` found for struct `rust_decimal::decimal::Decimal` in the current scope
 --> src/main.rs:4:32
  |
4 |     let from_string = Decimal::from_str("2.02").unwrap();
  |                                ^^^^^^^^ function or associated item not found in `rust_decimal::decimal::Decimal`
```