### PR TITLE
Added RoundingStrategy::{RoundUp, RoundDown}

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -119,10 +119,14 @@ pub struct Decimal {
 /// `RoundingStrategy::RoundHalfDown` - Rounds down if the value =< 5, otherwise rounds up, e.g.
 /// 6.5 -> 6, 6.51 -> 7
 /// 1.4999999 -> 1
+/// `RoundingStrategy::RoundDown` - Always round down.
+/// `RoundingStrategy::RoundUp` - Always round up.
 pub enum RoundingStrategy {
     BankersRounding,
     RoundHalfUp,
     RoundHalfDown,
+    RoundDown,
+    RoundUp,
 }
 
 #[allow(dead_code)]
@@ -771,6 +775,12 @@ impl Decimal {
                     _ => {}
                 }
             }
+            RoundingStrategy::RoundUp => {
+                if decimal_portion != [0, 0, 0] {
+                    add_internal(&mut value, &ONE_INTERNAL_REPR);
+                }
+            }
+            RoundingStrategy::RoundDown => (),
         }
 
         Decimal {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -776,7 +776,7 @@ impl Decimal {
                 }
             }
             RoundingStrategy::RoundUp => {
-                if decimal_portion != [0, 0, 0] {
+                if is_all_zero(&decimal_portion) {
                     add_internal(&mut value, &ONE_INTERNAL_REPR);
                 }
             }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -776,7 +776,7 @@ impl Decimal {
                 }
             }
             RoundingStrategy::RoundUp => {
-                if is_all_zero(&decimal_portion) {
+                if !is_all_zero(&decimal_portion) {
                     add_internal(&mut value, &ONE_INTERNAL_REPR);
                 }
             }

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -976,6 +976,30 @@ fn it_can_round_complex_numbers() {
 }
 
 #[test]
+fn it_can_round_down() {
+    let a = Decimal::new(470, 3).round_dp_with_strategy(1, RoundingStrategy::RoundDown);
+    assert_eq!("0.4", a.to_string());
+}
+
+#[test]
+fn it_only_rounds_down_when_needed() {
+    let a = Decimal::new(400, 3).round_dp_with_strategy(1, RoundingStrategy::RoundDown);
+    assert_eq!("0.4", a.to_string());
+}
+
+#[test]
+fn it_can_round_up() {
+    let a = Decimal::new(320, 3).round_dp_with_strategy(1, RoundingStrategy::RoundUp);
+    assert_eq!("0.4", a.to_string());
+}
+
+#[test]
+fn it_only_rounds_up_when_needed() {
+    let a = Decimal::new(300, 3).round_dp_with_strategy(1, RoundingStrategy::RoundUp);
+    assert_eq!("0.3", a.to_string());
+}
+
+#[test]
 fn it_can_trunc() {
     let tests = &[("1.00000000000000000000", "1"), ("1.000000000000000000000001", "1")];
 


### PR DESCRIPTION
The strategy `RoundUp` and `RoundDown` allow the user to unconditionally
round up or down, respectively.

I think this is technically a breaking change.