### PR TITLE
Fix edge case in from_i128_with_scale

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -34,7 +34,7 @@ const SIGN_SHIFT: u32 = 31;
 
 // The maximum supported precision
 const MAX_PRECISION: u32 = 28;
-// 281,474,976,710,655
+// 79,228,162,514,264,337,593,543,950,335
 const MAX_I128_REPR: i128 = 0x0000_0000_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF;
 
 static ONE_INTERNAL_REPR: [u32; 3] = [1, 0, 0];
@@ -197,12 +197,11 @@ impl Decimal {
         let mut wrapped = num;
         if num > MAX_I128_REPR {
             panic!("Number exceeds maximum value that can be represented");
+        } else if num < -MAX_I128_REPR {
+            panic!("Number less than minimum value that can be represented");
         } else if num < 0 {
             neg = true;
-            wrapped = num.wrapping_neg();
-            if wrapped > MAX_I128_REPR {
-                panic!("Number less than minimum value that can be represented");
-            }
+            wrapped = -num;
         }
         let flags: u32 = flags(neg, scale);
         Decimal {

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1543,3 +1543,9 @@ fn it_computes_equal_hashes_for_positive_and_negative_zero() {
     let h2 = hash_it(k2);
     assert_eq!(h1, h2);
 }
+
+#[test]
+#[should_panic]
+fn it_handles_i128_min() {
+    Decimal::from_i128_with_scale(i128::MIN, 0);
+}


### PR DESCRIPTION
`Decimal::from_i128_with_scale(i128::MIN, 0)` would incorrectly return `-0`. This was due to the fact that `i128::MIN.wrapping_neg() == i128::MIN`.