### PR TITLE
Make bytes and byteorder optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ license = "MIT"
 
 [dependencies]
 num-traits = "0.2"
-byteorder = "1.3"
-bytes = "0.5"
+byteorder = { version = "1.3", optional = true }
+bytes = { version = "0.5", optional = true }
 diesel = { version = "1.4", default-features = false, features = ["postgres"], optional = true }
 postgres = { version = "0.17", optional = true }
 tokio-postgres = { version = "0.5", optional = true }
@@ -26,11 +26,12 @@ serde_json = "1.0"
 serde_derive = "1.0"
 tokio = { version = "0.2", features = ["rt-threaded", "test-util", "macros"] }
 futures = "0.3"
+bytes = "0.5"
 
 [features]
 default = ["serde"]
 serde-float = ["serde"]
-tokio-pg = ["postgres", "tokio-postgres"]
+tokio-pg = ["postgres", "tokio-postgres", "bytes", "byteorder"]
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]


### PR DESCRIPTION
These are used only in `postgres` and `decimal_tests` so build them only when necessary