### PR TITLE
Reinstate support for bincode deserialization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,20 +35,50 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - name: Build rust-decimal
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all --all-features
-
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --all-features
-
       - name: Check file formatting
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --all -- --check
+          args: --workspace -- --check
+
+      - name: Build rust-decimal
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --workspace --all-features
+
+      - name: Run default tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --features default
+
+      - name: Run tests (postgres)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features postgres
+
+      - name: Run tests (tokio-pg)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features tokio-pg
+
+      - name: Run tests (diesel)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features diesel
+
+      - name: Run tests (serde-float)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features serde-float
+
+      - name: Run tests (serde-bincode)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features serde-bincode

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace
+          args: --workspace --all-features
 
       - name: Run default tests
         uses: actions-rs/cargo@v1
@@ -82,3 +82,9 @@ jobs:
         with:
           command: test
           args: --workspace --tests --features serde-bincode
+
+      - name: Run tests (serde-bincode + serde-float)
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features serde-bincode,serde-float

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --all-features
+          args: --workspace
 
       - name: Run default tests
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: fmt
-          args: --workspace -- --check
+          args: --all -- --check
 
       - name: Build rust-decimal
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,23 +53,23 @@ jobs:
           command: test
           args: --workspace --features default
 
-      - name: Run tests (postgres)
+      - name: Run tests (db-postgres)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --tests --features postgres
+          args: --workspace --tests --features db-postgres
 
-      - name: Run tests (tokio-pg)
+      - name: Run tests (db-tokio-postgres)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --tests --features tokio-pg
+          args: --workspace --tests --features db-tokio-postgres
 
-      - name: Run tests (diesel)
+      - name: Run tests (db-diesel-postgres)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --tests --features diesel
+          args: --workspace --tests --features db-diesel-postgres
 
       - name: Run tests (serde-float)
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,15 +21,17 @@ tokio-postgres = { version = "0.5", optional = true }
 serde = { version = "1.0", optional = true }
 
 [dev-dependencies]
+bincode = "1.3"
+bytes = "0.5"
+futures = "0.3"
 rand = "0.7"
 serde_json = "1.0"
 serde_derive = "1.0"
 tokio = { version = "0.2", features = ["rt-threaded", "test-util", "macros"] }
-futures = "0.3"
-bytes = "0.5"
 
 [features]
 default = ["serde"]
+serde-bincode = ["serde"]
 serde-float = ["serde"]
 tokio-pg = ["postgres", "tokio-postgres", "bytes", "byteorder"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,12 @@ tokio = { version = "0.2", features = ["rt-threaded", "test-util", "macros"] }
 
 [features]
 default = ["serde"]
+db-postgres = ["postgres", "bytes", "byteorder"]
+db-tokio-postgres = ["postgres", "tokio-postgres", "bytes", "byteorder"]
+db-diesel-postgres = ["diesel"]
 serde-bincode = ["serde"]
 serde-float = ["serde"]
-tokio-pg = ["postgres", "tokio-postgres", "bytes", "byteorder"]
+tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
 
 * [postgres](#postgres)
 * [tokio-pg](#tokio-pg)
+* [diesel](#diesel)
 * [serde-float](#serde-float)
+* [serde-bincode](#serde-bincode)
 
 ## `postgres`
 
@@ -55,6 +57,10 @@ type by transparently serializing/deserializing into the `NUMERIC` data type wit
 ## `tokio-pg`
 
 Enables the tokio postgres module allowing for async communication with PostgreSQL.
+
+## `diesel`
+
+Enable `diesel` PostgreSQL support. 
 
 ## `serde-float`
 
@@ -66,3 +72,10 @@ e.g. with this turned on, JSON serialization would output:
   "value": 1.234
 }
 ```
+
+## `serde-bincode`
+
+Since `bincode` does not specify type information, we need to ensure that a type hint is provided in order to 
+correctly be able to deserialize. Enabling this feature will force deserialization to use `deserialize_str` instead
+of `deserialize_any`. Because serialization uses string format by default, the feature `serde-float` should _*not*_ be 
+used in conjunction with this feature.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ e.g. with this turned on, JSON serialization would output:
 ## `serde-bincode`
 
 Since `bincode` does not specify type information, we need to ensure that a type hint is provided in order to 
-correctly be able to deserialize. Enabling this feature will force deserialization to use `deserialize_str` instead
-of `deserialize_any`. Because serialization uses string format by default, the feature `serde-float` should _*not*_ be 
-used in conjunction with this feature.
+correctly be able to deserialize. Enabling this feature on it's own will force deserialization to use `deserialize_str` 
+instead of `deserialize_any`. 
+
+If, for some reason, you also have `serde-float` enabled then this will use `deserialize_f64` as a type hint. Because
+converting to `f64` _loses_ precision, it's highly recommended that you do NOT enable this feature when working with 
+`bincode`. 

--- a/README.md
+++ b/README.md
@@ -43,22 +43,22 @@ let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
 
 ## Features
 
-* [postgres](#postgres)
-* [tokio-pg](#tokio-pg)
-* [diesel](#diesel)
+* [db-postgres](#db-postgres)
+* [db-tokio-postgres](#db-tokio-postgres)
+* [db-diesel-postgres](#db-diesel-postgres)
 * [serde-float](#serde-float)
 * [serde-bincode](#serde-bincode)
 
-## `postgres`
+## `db-postgres`
 
 This feature enables a PostgreSQL communication module. It allows for reading and writing the `Decimal`
 type by transparently serializing/deserializing into the `NUMERIC` data type within PostgreSQL.
 
-## `tokio-pg`
+## `db-tokio-postgres`
 
 Enables the tokio postgres module allowing for async communication with PostgreSQL.
 
-## `diesel`
+## `db-diesel-postgres`
 
 Enable `diesel` PostgreSQL support. 
 

--- a/README.md
+++ b/README.md
@@ -81,4 +81,4 @@ instead of `deserialize_any`.
 
 If, for some reason, you also have `serde-float` enabled then this will use `deserialize_f64` as a type hint. Because
 converting to `f64` _loses_ precision, it's highly recommended that you do NOT enable this feature when working with 
-`bincode`. 
+`bincode`. That being said, this will only use 8 bytes so is slightly more efficient in regards to storage size.

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -6,12 +6,23 @@ use serde::{self, de::Unexpected};
 
 use std::{fmt, str::FromStr};
 
+#[cfg(not(feature = "serde-bincode"))]
 impl<'de> serde::Deserialize<'de> for Decimal {
     fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>
     where
         D: serde::de::Deserializer<'de>,
     {
         deserializer.deserialize_any(DecimalVisitor)
+    }
+}
+
+#[cfg(feature = "serde-bincode")]
+impl<'de> serde::Deserialize<'de> for Decimal {
+    fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(DecimalVisitor)
     }
 }
 
@@ -95,6 +106,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(not(feature = "serde-bincode"))]
     fn deserialize_valid_decimal() {
         let data = [
             ("{\"amount\":\"1.234\"}", "1.234"),
@@ -147,5 +159,28 @@ mod test {
         };
         let serialized = serde_json::to_string(&record).unwrap();
         assert_eq!("{\"amount\":1.234}", serialized);
+    }
+
+    #[test]
+    #[cfg(feature = "serde-bincode")]
+    fn bincode_serialization() {
+        use bincode::{deserialize, serialize};
+
+        let data = [
+            "0",
+            "0.00",
+            "3.14159",
+            "-3.14159",
+            "1234567890123.4567890",
+            "-1234567890123.4567890",
+        ];
+        for &raw in data.iter() {
+            let value = Decimal::from_str(raw).unwrap();
+            let encoded = serialize(&value).unwrap();
+            let decoded: Decimal = deserialize(&encoded[..]).unwrap();
+
+            assert_eq!(value, decoded);
+            assert_eq!(8usize + raw.len(), encoded.len() as usize);
+        }
     }
 }

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -29,8 +29,8 @@ impl<'de> serde::Deserialize<'de> for Decimal {
 #[cfg(all(feature = "serde-bincode", feature = "serde-float"))]
 impl<'de> serde::Deserialize<'de> for Decimal {
     fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>
-        where
-            D: serde::de::Deserializer<'de>,
+    where
+        D: serde::de::Deserializer<'de>,
     {
         deserializer.deserialize_f64(DecimalVisitor)
     }

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -6,6 +6,9 @@ use serde::{self, de::Unexpected};
 
 use std::{fmt, str::FromStr};
 
+#[cfg(all(feature = "serde-bincode", feature = "serde-float"))]
+compile_error!("The features \"serde-bincode\" and \"serde-float\" cannot be enabled at the same time.");
+
 #[cfg(not(feature = "serde-bincode"))]
 impl<'de> serde::Deserialize<'de> for Decimal {
     fn deserialize<D>(deserializer: D) -> Result<Decimal, D::Error>


### PR DESCRIPTION
This reinstates bincode support by providing a type hint for deserialization when `serde-bincode` is enabled. This allows self-describing formats like JSON to continue supporting automatic casting.

When using this feature it's highly recommended that you _do not_ enable the feature `serde-float`. While it's possible to utilize this feature for byte savings, it does have the affect of losing precision.

This PR also cleans up other features. All features should still be backwards compatible (e.g. `tokio-pg` is an alias for the new `db-tokio-postgres`.

Fixes #43 