### PR TITLE
Use num_traits::float::FloatCore::powi() in no_std environments.

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -10,6 +10,8 @@ use core::{
 };
 #[cfg(feature = "diesel")]
 use diesel::sql_types::Numeric;
+#[cfg(not(feature = "std"))]
+use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
 
 // Sign mask for the flags field. A value of zero in this bit indicates a
@@ -2663,7 +2665,7 @@ impl ToPrimitive for Decimal {
             let frac_part = mantissa % precision;
             let frac_f64 = (frac_part as f64) / (precision as f64);
             let value = sign * ((integral_part as f64) + frac_f64);
-            let round_to = 10f64.powf(self.scale() as f64);
+            let round_to = 10f64.powi(self.scale() as i32);
             Some(value * round_to / round_to)
         }
     }


### PR DESCRIPTION
This should be an adequate solution for #286. `num_traits::float::FloatCore` provides `powi()` in `no_std` environments, which should actually be slightly faster than `powf()` was.