### PR TITLE
Update dependencies for tokio & postgres

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ byteorder = { default-features = false, optional = true, version = "1.3" }
 bytes = { default-features = false, optional = true, version = "0.5" }
 diesel = { default-features = false, features = ["postgres"], optional = true, version = "1.4" }
 num-traits = { default-features = false, version = "0.2" }
-postgres = { default-features = false, optional = true, version = "0.17" }
+postgres = { default-features = false, optional = true, version = "0.18" }
 serde = { default-features = false, optional = true, version = "1.0" }
-tokio-postgres = { default-features = false, optional = true, version = "0.5" }
+tokio-postgres = { default-features = false, optional = true, version = "0.6" }
 
 [dev-dependencies]
 bincode = "1.3"
@@ -27,7 +27,7 @@ futures = "0.3"
 rand = "0.7"
 serde_derive = "1.0"
 serde_json = "1.0"
-tokio = { features = ["rt-threaded", "test-util", "macros"], version = "0.2" }
+tokio = { features = ["rt-multi-thread", "test-util", "macros"], version = "0.3.4" }
 
 [features]
 db-diesel-postgres = ["diesel", "std"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,71 @@
+[config]
+default_to_workspace = false
+
+[tasks.build]
+command = "cargo"
+args = ["build"]
+
+[tasks.format]
+workspace = true
+install_crate = "rustfmt"
+command = "cargo"
+args = ["fmt", "--", "--emit=files"]
+
+[tasks.outdated]
+install_crate = "cargo-outdated"
+command = "cargo"
+args = ["outdated", "-R"]
+
+[tasks.test-all]
+dependencies = [
+    "test-no-std",
+    "test-default",
+    "test-db",
+    "test-serde"
+]
+
+[tasks.test-db]
+dependencies = [
+    "test-db-postgres",
+    "test-db-tokio-postgres",
+    "test-db-diesel-postgres"
+]
+
+[tasks.test-serde]
+dependencies = [
+    "test-serde-float",
+    "test-serde-bincode",
+    "test-serde-bincode-float"
+]
+
+[tasks.test-no-std]
+command = "cargo"
+args = ["test", "--no-default-features"]
+
+[tasks.test-default]
+command = "cargo"
+args = ["test", "--workspace", "--features=default"]
+
+[tasks.test-db-postgres]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=db-postgres"]
+
+[tasks.test-db-tokio-postgres]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=db-tokio-postgres"]
+
+[tasks.test-db-diesel-postgres]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=db-diesel-postgres"]
+
+[tasks.test-serde-float]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=serde-float"]
+
+[tasks.test-serde-bincode]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=serde-bincode"]
+
+[tasks.test-serde-bincode-float]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=serde-bincode,serde-float"]

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 [dependencies]
 clap = "2.32.0"
 decimal = "2.0.4"
-rand = "0.5"
+rand = "0.7"
 rust_decimal = { path = "../" }
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -473,7 +473,7 @@ mod diesel {
 #[cfg(feature = "postgres")]
 mod postgres {
     use super::*;
-    use ::postgres::types::*;
+    use ::postgres::types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
     use byteorder::{BigEndian, ReadBytesExt};
     use bytes::{BufMut, BytesMut};
     use std::io::Cursor;


### PR DESCRIPTION
This all adds in a `Makefile.toml` from [`cargo-make`](https://github.com/sagiegurari/cargo-make) which makes testing all iterations easier on local machines.

Fixes #284 