### PR TITLE
#271: Adds Scientific notation formatting to format strings

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,6 +5,12 @@ default_to_workspace = false
 command = "cargo"
 args = ["build"]
 
+# Always test no-std with std tests
+[tasks.test]
+dependencies = ["test-no-std"]
+command = "cargo"
+args = ["test"]
+
 [tasks.format]
 workspace = true
 install_crate = "rustfmt"

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -13,7 +13,6 @@ use diesel::sql_types::Numeric;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
-use serde::export::Formatter;
 
 // Sign mask for the flags field. A value of zero in this bit indicates a
 // positive Decimal value, and a value of one in this bit indicates a
@@ -2916,7 +2915,7 @@ impl fmt::Debug for Decimal {
     }
 }
 
-fn fmt_scientific_notation(value: &Decimal, exponent_symbol: &str, f: &mut Formatter<'_>) -> fmt::Result {
+fn fmt_scientific_notation(value: &Decimal, exponent_symbol: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     // Get the scale - this is the e value. With multiples of 10 this may get bigger.
     let mut exponent = -(value.scale() as isize);
 
@@ -2955,13 +2954,13 @@ fn fmt_scientific_notation(value: &Decimal, exponent_symbol: &str, f: &mut Forma
 }
 
 impl fmt::LowerExp for Decimal {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_scientific_notation(self, "e", f)
     }
 }
 
 impl fmt::UpperExp for Decimal {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt_scientific_notation(self, "E", f)
     }
 }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -13,6 +13,7 @@ use diesel::sql_types::Numeric;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+use serde::export::Formatter;
 
 // Sign mask for the flags field. A value of zero in this bit indicates a
 // positive Decimal value, and a value of one in this bit indicates a
@@ -2912,6 +2913,56 @@ impl fmt::Display for Decimal {
 impl fmt::Debug for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         fmt::Display::fmt(self, f)
+    }
+}
+
+fn fmt_scientific_notation(value: &Decimal, exponent_symbol: &str, f: &mut Formatter<'_>) -> fmt::Result {
+    // Get the scale - this is the e value. With multiples of 10 this may get bigger.
+    let mut exponent = -(value.scale() as isize);
+
+    // Convert the integral to a string
+    let mut chars = Vec::new();
+    let mut working = [value.lo, value.mid, value.hi];
+    while !is_all_zero(&working) {
+        let remainder = div_by_u32(&mut working, 10u32);
+        chars.push(char::from(b'0' + remainder as u8));
+    }
+
+    // First of all, apply scientific notation rules. That is:
+    //  1. If non-zero digit comes first, move decimal point left so that e is a positive integer
+    //  2. If decimal point comes first, move decimal point right until after the first non-zero digit
+    // Since decimal notation naturally lends itself this way, we just need to inject the decimal
+    // point in the right place and adjust the exponent accordingly.
+
+    let len = chars.len();
+    let mut rep;
+    if len > 1 {
+        if chars.iter().take(len - 1).all(|c| *c == '0') {
+            // Chomp off the zero's.
+            rep = chars.iter().skip(len - 1).collect::<String>();
+        } else {
+            chars.insert(len - 1, '.');
+            rep = chars.iter().rev().collect::<String>();
+        }
+        exponent += (len - 1) as isize;
+    } else {
+        rep = chars.iter().collect::<String>();
+    }
+
+    rep.push_str(exponent_symbol);
+    rep.push_str(&format!("{}", exponent));
+    f.pad_integral(value.is_sign_positive(), "", &rep)
+}
+
+impl fmt::LowerExp for Decimal {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt_scientific_notation(self, "e", f)
+    }
+}
+
+impl fmt::UpperExp for Decimal {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        fmt_scientific_notation(self, "E", f)
     }
 }
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2916,6 +2916,9 @@ impl fmt::Debug for Decimal {
 }
 
 fn fmt_scientific_notation(value: &Decimal, exponent_symbol: &str, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    #[cfg(not(feature = "std"))]
+    use alloc::string::ToString;
+
     // Get the scale - this is the e value. With multiples of 10 this may get bigger.
     let mut exponent = -(value.scale() as isize);
 
@@ -2949,7 +2952,7 @@ fn fmt_scientific_notation(value: &Decimal, exponent_symbol: &str, f: &mut fmt::
     }
 
     rep.push_str(exponent_symbol);
-    rep.push_str(&format!("{}", exponent));
+    rep.push_str(&exponent.to_string());
     f.pad_integral(value.is_sign_positive(), "", &rep)
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -165,6 +165,7 @@ fn it_formats_zero() {
     assert_eq!(format!("{:010.2}", a), "0000000.00");
     assert_eq!(format!("{:0<10.2}", a), "0.00000000");
 }
+
 #[test]
 fn it_formats_int() {
     let a = Decimal::from_str("5").unwrap();
@@ -174,6 +175,36 @@ fn it_formats_int() {
     assert_eq!(format!("{:.2}", a), "5.00");
     assert_eq!(format!("{:010.2}", a), "0000005.00");
     assert_eq!(format!("{:0<10.2}", a), "5.00000000");
+}
+
+#[test]
+fn it_formats_lower_exp() {
+    let tests = [
+        ("0.00001", "1e-5"),
+        ("-0.00001", "-1e-5"),
+        ("42.123", "4.2123e1"),
+        ("-42.123", "-4.2123e1"),
+        ("100", "1e2"),
+    ];
+    for (value, expected) in &tests {
+        let a = Decimal::from_str(value).unwrap();
+        assert_eq!(&format!("{:e}", a), *expected, "format!(\"{{:e}}\", {})", a);
+    }
+}
+
+#[test]
+fn it_formats_lower_exp_padding() {
+    let tests = [
+        ("0.00001", "01e-5"),
+        ("-0.00001", "-1e-5"),
+        ("42.123", "4.2123e1"),
+        ("-42.123", "-4.2123e1"),
+        ("100", "001e2"),
+    ];
+    for (value, expected) in &tests {
+        let a = Decimal::from_str(value).unwrap();
+        assert_eq!(&format!("{:05e}", a), *expected, "format!(\"{{:05e}}\", {})", a);
+    }
 }
 
 // Negation


### PR DESCRIPTION
Fixes #271 

Adds scientific notation formatting via `LowerExp` and `UpperExp` traits. 

e.g. `format!("{0:e}", "42.0")` outputs `4.2e1`