### PR TITLE
Add i128 and u128 overrides to prevent default trait implementation using u64

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2851,6 +2851,25 @@ impl ToPrimitive for Decimal {
             Some(value * round_to / round_to)
         }
     }
+
+    fn to_i128(&self) -> Option<i128> {
+        let d = self.trunc();
+        let raw: i128 = ((i128::from(d.hi) << 64) | i128::from(d.mid) << 32) | i128::from(d.lo);
+        if self.is_sign_negative() {
+            Some(-raw)
+        } else {
+            Some(raw)
+        }
+    }
+
+    fn to_u128(&self) -> Option<u128> {
+        if self.is_sign_negative() {
+            return None;
+        }
+
+        let d = self.trunc();
+        Some((u128::from(d.hi) << 64) | (u128::from(d.mid) << 32) | u128::from(d.lo))
+    }
 }
 
 impl fmt::Display for Decimal {

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1183,6 +1183,45 @@ fn it_converts_to_u64() {
 }
 
 #[test]
+fn it_converts_to_i128() {
+    assert_eq!(5i128, Decimal::from_str("5").unwrap().to_i128().unwrap());
+    assert_eq!(-5i128, Decimal::from_str("-5").unwrap().to_i128().unwrap());
+    assert_eq!(5i128, Decimal::from_str("5.12345").unwrap().to_i128().unwrap());
+    assert_eq!(-5i128, Decimal::from_str("-5.12345").unwrap().to_i128().unwrap());
+    assert_eq!(
+        0x7FFF_FFFF_FFFF_FFFF,
+        Decimal::from_str("9223372036854775807").unwrap().to_i128().unwrap()
+    );
+    assert_eq!(
+        92233720368547758089i128,
+        Decimal::from_str("92233720368547758089").unwrap().to_i128().unwrap()
+    );
+    assert_eq!(
+        79_228_162_514_264_337_593_543_950_335_i128,
+        Decimal::max_value().to_i128().unwrap()
+    );
+}
+
+#[test]
+fn it_converts_to_u128() {
+    assert_eq!(5u128, Decimal::from_str("5").unwrap().to_u128().unwrap());
+    assert_eq!(None, Decimal::from_str("-5").unwrap().to_u128());
+    assert_eq!(5u128, Decimal::from_str("5.12345").unwrap().to_u128().unwrap());
+    assert_eq!(
+        0xFFFF_FFFF_FFFF_FFFF,
+        Decimal::from_str("18446744073709551615").unwrap().to_u128().unwrap()
+    );
+    assert_eq!(
+        18446744073709551616u128,
+        Decimal::from_str("18446744073709551616").unwrap().to_u128().unwrap()
+    );
+    assert_eq!(
+        79_228_162_514_264_337_593_543_950_335_u128,
+        Decimal::max_value().to_u128().unwrap()
+    );
+}
+
+#[test]
 fn it_converts_from_f32() {
     fn from_f32(f: f32) -> Option<Decimal> {
         num_traits::FromPrimitive::from_f32(f)


### PR DESCRIPTION
Fixes #282

Adds overrides to `NumPrimitive` implementation to avoid the default behavior. The default behavior uses an `i64` or `u64` which reduces decimal precision which is unneeded.