### PR TITLE
Add arbitrary precision support for serde_json deserialization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,3 +94,9 @@ jobs:
         with:
           command: test
           args: --workspace --tests --features serde-str,serde-float
+
+      - name: Run tests (serde-arbitrary-precision)
+          uses: actions-rs/cargo@v1
+          with:
+            command: test
+            args: --workspace --tests --features serde-arbitrary-precision

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,13 +96,13 @@ jobs:
           args: --workspace --tests --features serde-str,serde-float
 
       - name: Run tests (serde-arbitrary-precision)
-          uses: actions-rs/cargo@v1
-          with:
-            command: test
-            args: --workspace --tests --features serde-arbitrary-precision
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features serde-arbitrary-precision
 
       - name: Run tests (serde-arbitrary-precision + serde-float)
-          uses: actions-rs/cargo@v1
-          with:
-            command: test
-            args: --workspace --tests --features serde-arbitrary-precision,serde-float
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --tests --features serde-arbitrary-precision,serde-float

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,3 +100,9 @@ jobs:
           with:
             command: test
             args: --workspace --tests --features serde-arbitrary-precision
+
+      - name: Run tests (serde-arbitrary-precision + serde-float)
+          uses: actions-rs/cargo@v1
+          with:
+            command: test
+            args: --workspace --tests --features serde-arbitrary-precision,serde-float

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ diesel = { default-features = false, features = ["postgres"], optional = true, v
 num-traits = { default-features = false, version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.18" }
 serde = { default-features = false, optional = true, version = "1.0" }
+serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.6" }
 
 [dev-dependencies]
@@ -37,6 +38,7 @@ default = ["serde", "std"]
 serde-bincode = ["serde-str"] # Backwards compatability
 serde-float = ["serde"]
 serde-str = ["serde"]
+serde-arbitrary-precision = ["serde", "serde_json/arbitrary_precision"]
 std = []
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -41,7 +41,8 @@ dependencies = [
 dependencies = [
     "test-serde-float",
     "test-serde-str",
-    "test-serde-str-float"
+    "test-serde-str-float",
+    "test-serde-arbitrary-precision"
 ]
 
 [tasks.test-no-std]
@@ -75,3 +76,7 @@ args = ["test", "--workspace", "--tests", "--features=serde-str"]
 [tasks.test-serde-str-float]
 command = "cargo"
 args = ["test", "--workspace", "--tests", "--features=serde-str,serde-float"]
+
+[tasks.test-serde-arbitrary-precision]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=serde-arbitrary-precision"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -42,7 +42,8 @@ dependencies = [
     "test-serde-float",
     "test-serde-str",
     "test-serde-str-float",
-    "test-serde-arbitrary-precision"
+    "test-serde-arbitrary-precision",
+    "test-serde-arbitrary-precision-float"
 ]
 
 [tasks.test-no-std]
@@ -80,3 +81,7 @@ args = ["test", "--workspace", "--tests", "--features=serde-str,serde-float"]
 [tasks.test-serde-arbitrary-precision]
 command = "cargo"
 args = ["test", "--workspace", "--tests", "--features=serde-arbitrary-precision"]
+
+[tasks.test-serde-arbitrary-precision-float]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=serde-arbitrary-precision,serde-float"]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,9 @@ converting to `f64` _loses_ precision, it's highly recommended that you do NOT e
 ## `serde-arbitrary-precision`
 
 This is used primarily with `serde_json` and consequently adds it as a "weak dependency". This supports the 
-`arbitrary_precision` feature inside `serde_json` when parsing decimals.
+`arbitrary_precision` feature inside `serde_json` when parsing decimals. 
+
+This is recommended when parsing "float" looking data as it will prevent data loss.
 
 ## `std`
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ If, for some reason, you also have `serde-float` enabled then this will use `des
 converting to `f64` _loses_ precision, it's highly recommended that you do NOT enable this feature when working with 
 `bincode`. That being said, this will only use 8 bytes so is slightly more efficient in regards to storage size.
 
+## `serde-arbitrary-precision`
+
+This is used primarily with `serde_json` and consequently adds it as a "weak dependency". This supports the 
+`arbitrary_precision` feature inside `serde_json` when parsing decimals.
+
 ## `std`
 
 Enable `std` library support. This is enabled by default, however in the future will be opt in. For now, to support `no_std`

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -34,6 +34,10 @@ impl<'de> serde::Deserialize<'de> for Decimal {
     }
 }
 
+// It's a shame this needs to be redefined for this feature and not able to be referenced directly
+#[cfg(feature = "serde-arbitrary-precision")]
+const DECIMAL_KEY_TOKEN: &str = "$serde_json::private::Number";
+
 struct DecimalVisitor;
 
 impl<'de> serde::de::Visitor<'de> for DecimalVisitor {
@@ -77,6 +81,90 @@ impl<'de> serde::de::Visitor<'de> for DecimalVisitor {
         Decimal::from_str(value)
             .or_else(|_| Decimal::from_scientific(value))
             .map_err(|_| E::invalid_value(Unexpected::Str(value), &self))
+    }
+
+    #[cfg(feature = "serde-arbitrary-precision")]
+    fn visit_map<A>(self, map: A) -> Result<Decimal, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut map = map;
+        let value = map.next_key::<DecimalKey>()?;
+        if value.is_none() {
+            return Err(serde::de::Error::invalid_type(Unexpected::Map, &self));
+        }
+        let v: DecimalFromString = map.next_value()?;
+        Ok(v.value)
+    }
+}
+
+#[cfg(feature = "serde-arbitrary-precision")]
+struct DecimalKey;
+
+#[cfg(feature = "serde-arbitrary-precision")]
+impl<'de> serde::de::Deserialize<'de> for DecimalKey {
+    fn deserialize<D>(deserializer: D) -> Result<DecimalKey, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        struct FieldVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for FieldVisitor {
+            type Value = ();
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a valid decimal field")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<(), E>
+            where
+                E: serde::de::Error,
+            {
+                if s == DECIMAL_KEY_TOKEN {
+                    Ok(())
+                } else {
+                    Err(serde::de::Error::custom("expected field with custom name"))
+                }
+            }
+        }
+
+        deserializer.deserialize_identifier(FieldVisitor)?;
+        Ok(DecimalKey)
+    }
+}
+
+#[cfg(feature = "serde-arbitrary-precision")]
+pub struct DecimalFromString {
+    pub value: Decimal,
+}
+
+#[cfg(feature = "serde-arbitrary-precision")]
+impl<'de> serde::de::Deserialize<'de> for DecimalFromString {
+    fn deserialize<D>(deserializer: D) -> Result<DecimalFromString, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = DecimalFromString;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("string containing a decimal")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<DecimalFromString, E>
+            where
+                E: serde::de::Error,
+            {
+                let d = Decimal::from_str(value)
+                    .or_else(|_| Decimal::from_scientific(value))
+                    .map_err(serde::de::Error::custom)?;
+                Ok(DecimalFromString { value: d })
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
     }
 }
 
@@ -125,7 +213,7 @@ mod test {
             assert_eq!(
                 true,
                 result.is_ok(),
-                "expected successful deseralization for {}. Error: {:?}",
+                "expected successful deserialization for {}. Error: {:?}",
                 serialized,
                 result.err().unwrap()
             );
@@ -138,6 +226,14 @@ mod test {
                 record.amount.to_string()
             );
         }
+    }
+
+    #[test]
+    #[cfg(feature = "serde-arbitrary-precision")]
+    fn deserialize_basic_decimal() {
+        let d: Decimal = serde_json::from_str("1.1234127836128763").unwrap();
+        // Typically, this would not work without this feature enabled due to rounding
+        assert_eq!(d.to_string(), "1.1234127836128763");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #283 

This adds a new feature `serde-arbitrary-precision` which has a weak dependency on `serde_json`'s feature `arbitrary_precision`. Consequently, it implements necessary structs so that this will deserialize without issue and avoid floating point precision issues without using string.