### PR TITLE
Faster serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ postgres = { default-features = false, optional = true, version = "0.18" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.6" }
+arrayvec = "0.5.2"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/benches/lib_benches.rs
+++ b/benches/lib_benches.rs
@@ -2,9 +2,9 @@
 
 extern crate test;
 
+use bincode::Options as _;
 use core::str::FromStr;
 use rust_decimal::Decimal;
-use bincode::Options as _;
 
 macro_rules! bench_decimal_op {
     ($name:ident, $op:tt, $y:expr) => {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1,5 +1,6 @@
 use crate::Error;
 use alloc::{string::String, vec::Vec};
+use arrayvec::{ArrayString, ArrayVec};
 use core::{
     cmp::{Ordering::Equal, *},
     fmt,
@@ -13,7 +14,6 @@ use diesel::sql_types::Numeric;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
-use arrayvec::{ArrayVec, ArrayString};
 
 // Sign mask for the flags field. A value of zero in this bit indicates a
 // positive Decimal value, and a value of one in this bit indicates a

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2496,7 +2496,9 @@ fn parse_str_radix_10(str: &str) -> Result<Decimal, Error> {
         };
 
         // Round at midpoint
-        let midpoint = 5;
+        // FIXME shouldn't this be
+        //let midpoint = 5;
+        let midpoint = 10;
         if digit >= midpoint {
             let mut index = coeff.len() - 1;
             loop {
@@ -2768,7 +2770,9 @@ impl Num for Decimal {
             };
 
             // Round at midpoint
-            let midpoint = if radix & 0x1 == 1 { radix / 2 } else { (radix + 1) / 2 };
+            // FIXME shouldn't this be
+            //let midpoint = if radix & 0x1 == 1 { radix / 2 } else { (radix + 1) / 2 };
+            let midpoint = if radix & 0x1 == 1 { radix / 2 } else { radix };
             if digit >= midpoint {
                 let mut index = coeff.len() - 1;
                 loop {
@@ -3139,7 +3143,7 @@ impl fmt::Display for Decimal {
         let mut chars = ArrayVec::<[_; 30]>::new();
         let mut working = [self.lo, self.mid, self.hi];
         while !is_all_zero(&working) {
-            let remainder = div_by_10(&mut working);
+            let remainder = div_by_u32(&mut working, 10u32);
             chars.push(char::from(b'0' + remainder as u8));
         }
         while scale > chars.len() {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2768,7 +2768,7 @@ impl Num for Decimal {
             };
 
             // Round at midpoint
-            let midpoint = if radix & 0x1 == 1 { radix / 2 } else { radix + 1 / 2 };
+            let midpoint = if radix & 0x1 == 1 { radix / 2 } else { (radix + 1) / 2 };
             if digit >= midpoint {
                 let mut index = coeff.len() - 1;
                 loop {
@@ -3089,6 +3089,7 @@ impl ToPrimitive for Decimal {
 // TODO add tests
 impl Decimal {
     // impl that doesn't allocate for serialization purposes.
+    #[cfg(not(feature = "serde-float"))]
     pub(crate) fn to_array_str(&self) -> impl AsRef<str> {
         // Get the scale - where we need to put the decimal point
         let scale = self.scale() as usize;

--- a/src/serde_types.rs
+++ b/src/serde_types.rs
@@ -174,7 +174,7 @@ impl serde::Serialize for Decimal {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.serialize_str(self.to_array_str().as_ref())
     }
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1323,6 +1323,7 @@ fn it_can_parse_highly_significant_numbers() {
             "8097370036018690744.2590371159596744091",
             "8097370036018690744.259037116",
         ),
+        ("1.234567890123456789012345678949999", "1.2345678901234567890123456789"),
     ];
     for &(value, expected) in tests {
         assert_eq!(expected, Decimal::from_str(value).unwrap().to_string());


### PR DESCRIPTION
I had a use case where my bottleneck was due to decimal deserialization via bincode, so I though I would do some low hanging fruit optimizations.

Feedback would be much appreciated.

## Overview
* Adds arrrayvec as a dependency since it will replace the heap allocated vectors and strings
* Removes heap allocation for both serialization & deserialization with the `serde-str` feature enable. This is done my removing heap allocation for the from_str impl as well as using a to_array_str impl instead of using to_string.
* Adds a from_str_radix specialization when radix is 10, since its the most common case (~25% performance improvement)
* Improve the to_string algorithm by making it 2 pass instead of 3 pass

## Outstanding issues
* Need to add tests for the `to_array_str` method
* Im not sure the constants I used for my arrays are the right ones. Basically we wanna use the highest possible size necessary otherwise it will panic when pushing a sufficiently long decimal.

## Performance improvements according to the micro benchmarks:
```
before:
test deserialize_bincode     ... bench:       6,544 ns/iter (+/- 3,308)
test serialize_bincode       ... bench:      15,397 ns/iter (+/- 7,748)
test decimal_to_string       ... bench:       7,288 ns/iter (+/- 77)
test decimal_from_str        ... bench:       5,684 ns/iter (+/- 180)

after:
test deserialize_bincode     ... bench:       2,884 ns/iter (+/- 1,448)
test serialize_bincode       ... bench:       5,248 ns/iter (+/- 57)
test decimal_to_string       ... bench:       4,203 ns/iter (+/- 48)
test decimal_from_str        ... bench:       1,592 ns/iter (+/- 810)
```
I also tested against my real life application and the performance improvements where similar. I got from about 500k reads/s to 1.3M reads/s. I did not test the serialization path however.