### PR TITLE
Add TryFrom for f32/f64 to/from Decimal

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -654,7 +654,7 @@ impl Decimal {
     /// ```
     pub fn max(self, other: Decimal) -> Decimal {
         if self < other {
-            return other;
+            other
         } else {
             self
         }
@@ -671,7 +671,7 @@ impl Decimal {
     /// ```
     pub fn min(self, other: Decimal) -> Decimal {
         if self > other {
-            return other;
+            other
         } else {
             self
         }
@@ -1507,7 +1507,7 @@ impl Decimal {
             result = (result + self / result) / TWO;
         }
 
-        return Some(result);
+        Some(result)
     }
 
     /// The natural logarithm for a Decimal. Uses a [fast estimation algorithm](https://en.wikipedia.org/wiki/Natural_logarithm#High_precision)
@@ -2711,10 +2711,8 @@ mod ops {
                                 tmp <<= 1;
                                 if tmp > divisor64 {
                                     true
-                                } else if tmp == divisor64 && quotient.lo & 0x1 != 0 {
-                                    true
                                 } else {
-                                    false
+                                    tmp == divisor64 && quotient.lo & 0x1 != 0
                                 }
                             };
 
@@ -2811,10 +2809,8 @@ mod ops {
                                     let divisor_low64 = divisor.low64();
                                     if rem_low64 > divisor_low64 {
                                         true
-                                    } else if rem_low64 == divisor_low64 && (quotient.lo & 1) != 0 {
-                                        true
                                     } else {
-                                        false
+                                        rem_low64 == divisor_low64 && (quotient.lo & 1) != 0
                                     }
                                 } else {
                                     false
@@ -3142,7 +3138,7 @@ fn arithmetic_geo_mean_of_2(a: &Decimal, b: &Decimal) -> Decimal {
     let diff = (a - b).abs();
 
     if diff < TOLERANCE {
-        a.clone()
+        *a
     } else {
         arithmetic_geo_mean_of_2(&mean_of_2(a, b), &geo_mean_of_2(a, b))
     }
@@ -3955,6 +3951,38 @@ impl ToPrimitive for Decimal {
             let round_to = 10f64.powi(self.scale() as i32);
             Some(value * round_to / round_to)
         }
+    }
+}
+
+impl core::convert::TryFrom<f32> for Decimal {
+    type Error = crate::Error;
+
+    fn try_from(value: f32) -> Result<Self, Error> {
+        Self::from_f32(value).ok_or_else(|| Error::new("Failed to convert to Decimal"))
+    }
+}
+
+impl core::convert::TryFrom<f64> for Decimal {
+    type Error = crate::Error;
+
+    fn try_from(value: f64) -> Result<Self, Error> {
+        Self::from_f64(value).ok_or_else(|| Error::new("Failed to convert to Decimal"))
+    }
+}
+
+impl core::convert::TryFrom<Decimal> for f32 {
+    type Error = crate::Error;
+
+    fn try_from(value: Decimal) -> Result<Self, Self::Error> {
+        Decimal::to_f32(&value).ok_or_else(|| Error::new("Failed to convert to f32"))
+    }
+}
+
+impl core::convert::TryFrom<Decimal> for f64 {
+    type Error = crate::Error;
+
+    fn try_from(value: Decimal) -> Result<Self, Self::Error> {
+        Decimal::to_f64(&value).ok_or_else(|| Error::new("Failed to convert to f64"))
     }
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1,5 +1,6 @@
 use core::{
     cmp::{Ordering, Ordering::*},
+    convert::{TryFrom, TryInto},
     str::FromStr,
 };
 use num_traits::{One, Signed, ToPrimitive, Zero};
@@ -1182,6 +1183,33 @@ fn it_converts_to_f64() {
 }
 
 #[test]
+fn it_converts_to_f64_try() {
+    let tests = &[
+        ("5", Some(5f64)),
+        ("-5", Some(-5f64)),
+        ("0.1", Some(0.1f64)),
+        ("0.0", Some(0f64)),
+        ("-0.0", Some(0f64)),
+        ("0.0000000000025", Some(0.25e-11f64)),
+        ("1000000.0000000000025", Some(1e6f64)),
+        ("0.000000000000000000000000025", Some(0.25e-25_f64)),
+        (
+            "2.1234567890123456789012345678",
+            Some(2.1234567890123456789012345678_f64),
+        ),
+        (
+            "21234567890123456789012345678",
+            None, // Cannot be represented in an f64
+        ),
+        ("1.59283191", Some(1.59283191_f64)),
+    ];
+    for &(value, expected) in tests {
+        let value = Decimal::from_str(value).unwrap().try_into().ok();
+        assert_eq!(expected, value);
+    }
+}
+
+#[test]
 fn it_converts_to_i64() {
     assert_eq!(5i64, Decimal::from_str("5").unwrap().to_i64().unwrap());
     assert_eq!(-5i64, Decimal::from_str("-5").unwrap().to_i64().unwrap());
@@ -1273,6 +1301,38 @@ fn it_converts_from_f32() {
 }
 
 #[test]
+fn it_converts_from_f32_try() {
+    assert_eq!("1", Decimal::try_from(1f32).unwrap().to_string());
+    assert_eq!("0", Decimal::try_from(0f32).unwrap().to_string());
+    assert_eq!("0.12345", Decimal::try_from(0.12345f32).unwrap().to_string());
+    assert_eq!(
+        "0.12345678",
+        Decimal::try_from(0.1234567800123456789012345678f32)
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "0.12345679",
+        Decimal::try_from(0.12345678901234567890123456789f32)
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "0",
+        Decimal::try_from(0.00000000000000000000000000001f32)
+            .unwrap()
+            .to_string()
+    );
+
+    assert!(Decimal::try_from(core::f32::NAN).is_err());
+    assert!(Decimal::try_from(core::f32::INFINITY).is_err());
+
+    // These both overflow
+    assert!(Decimal::try_from(core::f32::MAX).is_err());
+    assert!(Decimal::try_from(core::f32::MIN).is_err());
+}
+
+#[test]
 fn it_converts_from_f64() {
     fn from_f64(f: f64) -> Option<Decimal> {
         num_traits::FromPrimitive::from_f64(f)
@@ -1300,6 +1360,44 @@ fn it_converts_from_f64() {
     // These both overflow
     assert!(from_f64(core::f64::MAX).is_none());
     assert!(from_f64(core::f64::MIN).is_none());
+}
+
+#[test]
+fn it_converts_from_f64_try() {
+    assert_eq!("1", Decimal::try_from(1f64).unwrap().to_string());
+    assert_eq!("0", Decimal::try_from(0f64).unwrap().to_string());
+    assert_eq!("0.12345", Decimal::try_from(0.12345f64).unwrap().to_string());
+    assert_eq!(
+        "0.1234567890123456",
+        Decimal::try_from(0.1234567890123456089012345678f64)
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "0.1234567890123457",
+        Decimal::try_from(0.12345678901234567890123456789f64)
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!(
+        "0",
+        Decimal::try_from(0.00000000000000000000000000001f64)
+            .unwrap()
+            .to_string()
+    );
+    assert_eq!("0.6927", Decimal::try_from(0.6927f64).unwrap().to_string());
+    assert_eq!("0.00006927", Decimal::try_from(0.00006927f64).unwrap().to_string());
+    assert_eq!(
+        "0.000000006927",
+        Decimal::try_from(0.000000006927f64).unwrap().to_string()
+    );
+
+    assert!(Decimal::try_from(core::f64::NAN).is_err());
+    assert!(Decimal::try_from(core::f64::INFINITY).is_err());
+
+    // These both overflow
+    assert!(Decimal::try_from(core::f64::MAX).is_err());
+    assert!(Decimal::try_from(core::f64::MIN).is_err());
 }
 
 #[test]


### PR DESCRIPTION
Implement TryFrom\<f32/f64\> for Decimal
Implement TryFrom\<Decimal\> for f32/f64
Add tests for try_into f64, try_from f32/f64
Fix some clippy lints
- Remove unnecessary returns
- Remove unnecessary clone on Copy type
- Simplify if-chain that returned bool instead of the conditional

This should close #265