### PR TITLE
Fix no-std environment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,14 @@ version = "1.9.0"
 
 [dependencies]
 byteorder = { default-features = false, optional = true, version = "1.3" }
-bytes = { default-features = false, optional = true, version = "1.0.0" }
+bytes = { default-features = false, optional = true, version = "1.0" }
 diesel = { default-features = false, features = ["postgres"], optional = true, version = "1.4" }
 num-traits = { default-features = false, version = "0.2" }
-postgres = { default-features = false, optional = true, version = "0.19.0" }
+postgres = { default-features = false, optional = true, version = "0.19" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
-tokio-postgres = { default-features = false, optional = true, version = "0.7.0" }
-arrayvec = "0.5.2"
+tokio-postgres = { default-features = false, optional = true, version = "0.7" }
+arrayvec = { default-features = false, version = "0.5" }
 
 [dev-dependencies]
 bincode = "1.3"
@@ -42,7 +42,7 @@ serde-bincode = ["serde-str"] # Backwards compatability
 serde-float = ["serde"]
 serde-str = ["serde"]
 serde-arbitrary-precision = ["serde", "serde_json/arbitrary_precision"]
-std = []
+std = ["arrayvec/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [workspace]


### PR DESCRIPTION
The default features of `arrayvec` assume a std environment