### PR TITLE
Refactor mathematical functions into an explicit feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,12 @@ jobs:
           command: make
           args: test-legacy-ops
 
+      - name: Run mathematical function tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: test-maths
+
       - name: Run database tests
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ db-postgres = ["byteorder", "bytes", "postgres", "std"]
 db-tokio-postgres = ["byteorder", "bytes", "postgres", "std", "tokio-postgres"]
 default = ["serde", "std"]
 legacy-ops = []
+maths = []
 serde-bincode = ["serde-str"] # Backwards compatability
 serde-float = ["serde"]
 serde-str = ["serde"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -37,6 +37,7 @@ dependencies = [
     "test-no-std",
     "test-default",
     "test-legacy-ops",
+    "test-maths",
     "test-db",
     "test-serde"
 ]
@@ -68,6 +69,10 @@ args = ["test", "--workspace", "--features=default"]
 [tasks.test-legacy-ops]
 command = "cargo"
 args = ["test", "--workspace", "--features=legacy-ops"]
+
+[tasks.test-maths]
+command = "cargo"
+args = ["test", "--workspace", "--no-default-features", "--features=maths"]
 
 [tasks.test-db-postgres]
 command = "cargo"

--- a/benches/lib_benches.rs
+++ b/benches/lib_benches.rs
@@ -218,123 +218,128 @@ fn to_from_sql(b: &mut ::test::Bencher) {
     });
 }
 
-#[bench]
-fn powi(b: &mut ::test::Bencher) {
-    // These exponents have to be fairly small because multiplcation overflows easily
-    let samples = &[
-        (Decimal::from_str("36.7").unwrap(), 5),
-        (Decimal::from_str("0.00000007").unwrap(), 5),
-        (Decimal::from(2), 64),
-        (Decimal::from_str("8819287.19276555").unwrap(), 3),
-        (Decimal::from_str("-8819287.19276555").unwrap(), 3),
-    ];
-    b.iter(|| {
-        for sample in samples.iter() {
-            let result = sample.0.powi(sample.1);
-            ::test::black_box(result);
-        }
-    });
-}
+#[cfg(feature = "maths")]
+mod maths {
+    use rust_decimal::prelude::*;
 
-#[bench]
-fn sqrt(b: &mut ::test::Bencher) {
-    let samples = &[
-        Decimal::from_str("36.7").unwrap(),
-        Decimal::from_str("0.00000007").unwrap(),
-        Decimal::from(2),
-        Decimal::from_str("8819287.19276555").unwrap(),
-        Decimal::from_str("-8819287.19276555").unwrap(),
-    ];
-    b.iter(|| {
-        for sample in samples.iter() {
-            let result = sample.sqrt();
-            ::test::black_box(result);
-        }
-    });
-}
+    #[bench]
+    fn powi(b: &mut ::test::Bencher) {
+        // These exponents have to be fairly small because multiplcation overflows easily
+        let samples = &[
+            (Decimal::from_str("36.7").unwrap(), 5),
+            (Decimal::from_str("0.00000007").unwrap(), 5),
+            (Decimal::from(2), 64),
+            (Decimal::from_str("8819287.19276555").unwrap(), 3),
+            (Decimal::from_str("-8819287.19276555").unwrap(), 3),
+        ];
+        b.iter(|| {
+            for sample in samples.iter() {
+                let result = sample.0.powi(sample.1);
+                ::test::black_box(result);
+            }
+        });
+    }
 
-#[bench]
-fn exp(b: &mut ::test::Bencher) {
-    let samples = &[
-        Decimal::from_str("3.7").unwrap(),
-        Decimal::from_str("0.07").unwrap(),
-        Decimal::from(2),
-        Decimal::from_str("8.19").unwrap(),
-        Decimal::from_str("-8.19").unwrap(),
-    ];
-    b.iter(|| {
-        for sample in samples.iter() {
-            let result = sample.exp();
-            ::test::black_box(result);
-        }
-    });
-}
+    #[bench]
+    fn sqrt(b: &mut ::test::Bencher) {
+        let samples = &[
+            Decimal::from_str("36.7").unwrap(),
+            Decimal::from_str("0.00000007").unwrap(),
+            Decimal::from(2),
+            Decimal::from_str("8819287.19276555").unwrap(),
+            Decimal::from_str("-8819287.19276555").unwrap(),
+        ];
+        b.iter(|| {
+            for sample in samples.iter() {
+                let result = sample.sqrt();
+                ::test::black_box(result);
+            }
+        });
+    }
 
-#[bench]
-fn norm_cdf(b: &mut ::test::Bencher) {
-    let samples = &[
-        Decimal::from_str("3.7").unwrap(),
-        Decimal::from_str("0.007").unwrap(),
-        Decimal::from(2),
-        Decimal::from_str("1.19").unwrap(),
-        Decimal::from_str("-1.19").unwrap(),
-    ];
-    b.iter(|| {
-        for sample in samples.iter() {
-            let result = sample.norm_cdf();
-            ::test::black_box(result);
-        }
-    });
-}
+    #[bench]
+    fn exp(b: &mut ::test::Bencher) {
+        let samples = &[
+            Decimal::from_str("3.7").unwrap(),
+            Decimal::from_str("0.07").unwrap(),
+            Decimal::from(2),
+            Decimal::from_str("8.19").unwrap(),
+            Decimal::from_str("-8.19").unwrap(),
+        ];
+        b.iter(|| {
+            for sample in samples.iter() {
+                let result = sample.exp();
+                ::test::black_box(result);
+            }
+        });
+    }
 
-#[bench]
-fn norm_pdf(b: &mut ::test::Bencher) {
-    let samples = &[
-        Decimal::from_str("3.7").unwrap(),
-        Decimal::from_str("0.007").unwrap(),
-        Decimal::from(2),
-        Decimal::from_str("1.19").unwrap(),
-        Decimal::from_str("-1.19").unwrap(),
-    ];
-    b.iter(|| {
-        for sample in samples.iter() {
-            let result = sample.norm_pdf();
-            ::test::black_box(result);
-        }
-    });
-}
+    #[bench]
+    fn norm_cdf(b: &mut ::test::Bencher) {
+        let samples = &[
+            Decimal::from_str("3.7").unwrap(),
+            Decimal::from_str("0.007").unwrap(),
+            Decimal::from(2),
+            Decimal::from_str("1.19").unwrap(),
+            Decimal::from_str("-1.19").unwrap(),
+        ];
+        b.iter(|| {
+            for sample in samples.iter() {
+                let result = sample.norm_cdf();
+                ::test::black_box(result);
+            }
+        });
+    }
 
-#[bench]
-fn ln(b: &mut ::test::Bencher) {
-    let samples = &[
-        Decimal::from_str("36.7").unwrap(),
-        Decimal::from_str("0.00000007").unwrap(),
-        Decimal::from(2),
-        Decimal::from_str("8819287.19").unwrap(),
-        Decimal::from_str("-8819287.19").unwrap(),
-    ];
-    b.iter(|| {
-        for sample in samples.iter() {
-            let result = sample.ln();
-            ::test::black_box(result);
-        }
-    });
-}
+    #[bench]
+    fn norm_pdf(b: &mut ::test::Bencher) {
+        let samples = &[
+            Decimal::from_str("3.7").unwrap(),
+            Decimal::from_str("0.007").unwrap(),
+            Decimal::from(2),
+            Decimal::from_str("1.19").unwrap(),
+            Decimal::from_str("-1.19").unwrap(),
+        ];
+        b.iter(|| {
+            for sample in samples.iter() {
+                let result = sample.norm_pdf();
+                ::test::black_box(result);
+            }
+        });
+    }
 
-#[bench]
-fn erf(b: &mut ::test::Bencher) {
-    let samples = &[
-        Decimal::from(0),
-        Decimal::from(1),
-        Decimal::from_str("-0.98717").unwrap(),
-        Decimal::from_str("0.07").unwrap(),
-        Decimal::from_str("0.1111").unwrap(),
-        Decimal::from_str("0.4").unwrap(),
-    ];
-    b.iter(|| {
-        for sample in samples.iter() {
-            let result = sample.erf();
-            ::test::black_box(result);
-        }
-    });
+    #[bench]
+    fn ln(b: &mut ::test::Bencher) {
+        let samples = &[
+            Decimal::from_str("36.7").unwrap(),
+            Decimal::from_str("0.00000007").unwrap(),
+            Decimal::from(2),
+            Decimal::from_str("8819287.19").unwrap(),
+            Decimal::from_str("-8819287.19").unwrap(),
+        ];
+        b.iter(|| {
+            for sample in samples.iter() {
+                let result = sample.ln();
+                ::test::black_box(result);
+            }
+        });
+    }
+
+    #[bench]
+    fn erf(b: &mut ::test::Bencher) {
+        let samples = &[
+            Decimal::from(0),
+            Decimal::from(1),
+            Decimal::from_str("-0.98717").unwrap(),
+            Decimal::from_str("0.07").unwrap(),
+            Decimal::from_str("0.1111").unwrap(),
+            Decimal::from_str("0.4").unwrap(),
+        ];
+        b.iter(|| {
+            for sample in samples.iter() {
+                let result = sample.erf();
+                ::test::black_box(result);
+            }
+        });
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ extern crate alloc;
 mod decimal;
 mod error;
 
+#[cfg(feature = "maths")]
+mod maths;
 #[cfg(any(feature = "postgres", feature = "diesel"))]
 mod postgres;
 #[cfg(feature = "serde")]
@@ -48,8 +50,12 @@ mod serde_types;
 
 pub use decimal::{Decimal, RoundingStrategy};
 pub use error::Error;
+#[cfg(feature = "maths")]
+pub use maths::MathematicalOps;
 
 pub mod prelude {
+    #[cfg(feature = "maths")]
+    pub use crate::maths::MathematicalOps;
     pub use crate::{Decimal, RoundingStrategy};
     pub use core::str::FromStr;
     pub use num_traits::{FromPrimitive, One, ToPrimitive, Zero};

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -1,0 +1,257 @@
+use crate::prelude::*;
+
+const TWO: Decimal = Decimal::from_parts_raw(2, 0, 0, 0);
+const PI: Decimal = Decimal::from_parts_raw(1102470953, 185874565, 1703060790, 1835008);
+const LN2: Decimal = Decimal::from_parts_raw(2831677809, 328455696, 3757558395, 1900544);
+
+pub trait MathematicalOps {
+    /// The estimated exponential function, e<sup>x</sup>, rounded to 8 decimal places. Stops
+    /// calculating when it is within tolerance is roughly 0.000002 in order to prevent
+    /// multiplication overflow.
+    fn exp(&self) -> Decimal;
+
+    /// The estimated exponential function, e<sup>x</sup>, rounded to 8 decimal places. Stops
+    /// calculating when it is within `tolerance`.
+    /// Multiplication overflows are likely if you are not careful with the size of `tolerance`.
+    /// It is recommended to set the `tolerance` larger for larger numbers and smaller for smaller
+    /// numbers to avoid multiplication overflow.
+    fn exp_with_tolerance(&self, tolerance: Decimal) -> Decimal;
+
+    /// Raise self to the given unsigned integer exponent: x<sup>y</sup>
+    fn powi(&self, exp: u64) -> Decimal;
+
+    /// The square root of a Decimal. Uses a standard Babylonian method.
+    fn sqrt(&self) -> Option<Decimal>;
+
+    /// The natural logarithm for a Decimal. Uses a [fast estimation algorithm](https://en.wikipedia.org/wiki/Natural_logarithm#High_precision)
+    /// This is more accurate on larger numbers and less on numbers less than 1.
+    fn ln(&self) -> Decimal;
+
+    /// Abramowitz Approximation of Error Function from [wikipedia](https://en.wikipedia.org/wiki/Error_function#Numerical_approximations)
+    fn erf(&self) -> Decimal;
+
+    /// The Cumulative distribution function for a Normal distribution
+    fn norm_cdf(&self) -> Decimal;
+
+    /// The Probability density function for a Normal distribution
+    fn norm_pdf(&self) -> Decimal;
+}
+
+impl MathematicalOps for Decimal {
+    /// The estimated exponential function, e<sup>x</sup>, rounded to 8 decimal places. Stops
+    /// calculating when it is within tolerance is roughly 0.000002 in order to prevent
+    /// multiplication overflow.
+    fn exp(&self) -> Decimal {
+        let tolerance = Decimal::new(2, 7);
+        self.exp_with_tolerance(tolerance)
+    }
+
+    /// The estimated exponential function, e<sup>x</sup>, rounded to 8 decimal places. Stops
+    /// calculating when it is within `tolerance`.
+    /// Multiplication overflows are likely if you are not careful with the size of `tolerance`.
+    /// It is recommended to set the `tolerance` larger for larger numbers and smaller for smaller
+    /// numbers to avoid multiplication overflow.
+    #[inline]
+    fn exp_with_tolerance(&self, tolerance: Decimal) -> Decimal {
+        if self == &Decimal::zero() {
+            return Decimal::one();
+        }
+
+        let mut term = *self;
+        let mut result = self + Decimal::one();
+        let mut prev_result = Decimal::zero();
+        let mut factorial = Decimal::one();
+        let mut n = TWO;
+        let twenty_four = Decimal::new(24, 0);
+
+        // Needs rounding because multiplication overflows otherwise.
+        while (result - prev_result).abs() > tolerance && n < twenty_four {
+            prev_result = result;
+            term = self * term.round_dp(8);
+            factorial *= n;
+            result += (term / factorial).round_dp(8);
+            n += Decimal::one();
+        }
+
+        result
+    }
+
+    /// Raise self to the given unsigned integer exponent: x<sup>y</sup>
+    fn powi(&self, exp: u64) -> Decimal {
+        match exp {
+            0 => Decimal::one(),
+            1 => *self,
+            2 => self * self,
+            _ => {
+                // Square self once and make an infinite sized iterator of the square.
+                let i = core::iter::repeat(self * self);
+
+                // We then take half of the exponent to create a finite iterator and then multiply those together.
+                let product = i
+                    .take((exp / 2) as usize)
+                    .fold(Decimal::one(), |accumulator, x| accumulator * x);
+
+                // If the exponent is odd we still need to multiply once more
+                if exp % 2 > 0 {
+                    product * self
+                } else {
+                    product
+                }
+            }
+        }
+    }
+
+    /// The square root of a Decimal. Uses a standard Babylonian method.
+    fn sqrt(&self) -> Option<Decimal> {
+        if self.is_sign_negative() {
+            return None;
+        }
+
+        if self.is_zero() {
+            return Some(Decimal::zero());
+        }
+
+        // Start with an arbitrary number as the first guess
+        let mut result = self / TWO;
+        let mut last = result + Decimal::one();
+
+        // Keep going while the difference is larger than the tolerance
+        let mut circuit_breaker = 0;
+        while last != result {
+            circuit_breaker += 1;
+            assert!(circuit_breaker < 1000, "geo mean circuit breaker");
+
+            last = result;
+            result = (result + self / result) / TWO;
+        }
+
+        Some(result)
+    }
+
+    /// The natural logarithm for a Decimal. Uses a [fast estimation algorithm](https://en.wikipedia.org/wiki/Natural_logarithm#High_precision)
+    /// This is more accurate on larger numbers and less on numbers less than 1.
+    fn ln(&self) -> Decimal {
+        if self.is_sign_positive() {
+            if self == &Decimal::one() {
+                Decimal::zero()
+            } else {
+                let s = self * Decimal::new(256, 0);
+                let arith_geo_mean = arithmetic_geo_mean_of_2(&Decimal::one(), &(Decimal::new(4, 0) / s));
+
+                PI / (arith_geo_mean * TWO) - (Decimal::new(8, 0) * LN2)
+            }
+        } else {
+            Decimal::zero()
+        }
+    }
+
+    /// Abramowitz Approximation of Error Function from [wikipedia](https://en.wikipedia.org/wiki/Error_function#Numerical_approximations)
+    fn erf(&self) -> Decimal {
+        if self.is_sign_positive() {
+            let one = &Decimal::one();
+
+            let xa1 = self * Decimal::from_str("0.0705230784").unwrap();
+            let xa2 = self.powi(2) * Decimal::from_str("0.0422820123").unwrap();
+            let xa3 = self.powi(3) * Decimal::from_str("0.0092705272").unwrap();
+            let xa4 = self.powi(4) * Decimal::from_str("0.0001520143").unwrap();
+            let xa5 = self.powi(5) * Decimal::from_str("0.0002765672").unwrap();
+            let xa6 = self.powi(6) * Decimal::from_str("0.0000430638").unwrap();
+
+            let sum = one + xa1 + xa2 + xa3 + xa4 + xa5 + xa6;
+            one - (one / sum.powi(16))
+        } else {
+            -self.abs().erf()
+        }
+    }
+
+    /// The Cumulative distribution function for a Normal distribution
+    fn norm_cdf(&self) -> Decimal {
+        (Decimal::one() + (self / Decimal::from_str("1.4142135623730951").unwrap()).erf()) / TWO
+    }
+
+    /// The Probability density function for a Normal distribution
+    fn norm_pdf(&self) -> Decimal {
+        let sqrt2pi = Decimal::from_parts_raw(2133383024, 2079885984, 1358845910, 1835008);
+        (-self.powi(2) / TWO).exp() / sqrt2pi
+    }
+}
+
+/// Returns the convergence of both the arithmetic and geometric mean.
+/// Used internally.
+fn arithmetic_geo_mean_of_2(a: &Decimal, b: &Decimal) -> Decimal {
+    const TOLERANCE: Decimal = Decimal::from_parts(5, 0, 0, false, 7);
+    let diff = (a - b).abs();
+
+    if diff < TOLERANCE {
+        *a
+    } else {
+        arithmetic_geo_mean_of_2(&mean_of_2(a, b), &geo_mean_of_2(a, b))
+    }
+}
+
+/// The Arithmetic mean. Used internally.
+fn mean_of_2(a: &Decimal, b: &Decimal) -> Decimal {
+    (a + b) / TWO
+}
+
+/// The geometric mean. Used internally.
+fn geo_mean_of_2(a: &Decimal, b: &Decimal) -> Decimal {
+    (a * b).sqrt().unwrap()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use std::str::FromStr;
+
+    #[test]
+    fn test_geo_mean_of_2() {
+        let test_cases = &[
+            (
+                Decimal::from_str("2").unwrap(),
+                Decimal::from_str("2").unwrap(),
+                Decimal::from_str("2").unwrap(),
+            ),
+            (
+                Decimal::from_str("4").unwrap(),
+                Decimal::from_str("3").unwrap(),
+                Decimal::from_str("3.4641016151377545870548926830").unwrap(),
+            ),
+            (
+                Decimal::from_str("12").unwrap(),
+                Decimal::from_str("3").unwrap(),
+                Decimal::from_str("6.000000000000000000000000000").unwrap(),
+            ),
+        ];
+
+        for case in test_cases {
+            assert_eq!(case.2, geo_mean_of_2(&case.0, &case.1));
+        }
+    }
+
+    #[test]
+    fn test_mean_of_2() {
+        let test_cases = &[
+            (
+                Decimal::from_str("2").unwrap(),
+                Decimal::from_str("2").unwrap(),
+                Decimal::from_str("2").unwrap(),
+            ),
+            (
+                Decimal::from_str("4").unwrap(),
+                Decimal::from_str("3").unwrap(),
+                Decimal::from_str("3.5").unwrap(),
+            ),
+            (
+                Decimal::from_str("12").unwrap(),
+                Decimal::from_str("3").unwrap(),
+                Decimal::from_str("7.5").unwrap(),
+            ),
+        ];
+
+        for case in test_cases {
+            assert_eq!(case.2, mean_of_2(&case.0, &case.1));
+        }
+    }
+}

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3,7 +3,7 @@ use core::{
     convert::{TryFrom, TryInto},
     str::FromStr,
 };
-use num_traits::{One, Signed, ToPrimitive, Zero};
+use num_traits::{Signed, ToPrimitive, Zero};
 use rust_decimal::{Decimal, RoundingStrategy};
 
 macro_rules! either {
@@ -1823,259 +1823,268 @@ fn it_can_rescale() {
     }
 }
 
-#[test]
-fn test_powi() {
-    let test_cases = &[
-        (Decimal::new(4, 0), 3_u64, Decimal::new(64, 0)),
-        (
-            Decimal::from_str("3.222").unwrap(),
-            5_u64,
-            Decimal::from_str("347.238347228449632").unwrap(),
-        ),
-        (
-            Decimal::from_str("0.1").unwrap(),
-            0_u64,
-            Decimal::from_str("1").unwrap(),
-        ),
-        (
-            Decimal::from_str("342.4").unwrap(),
-            1_u64,
-            Decimal::from_str("342.4").unwrap(),
-        ),
-        (
-            Decimal::from_str("2.0").unwrap(),
-            16_u64,
-            Decimal::from_str("65536").unwrap(),
-        ),
-    ];
-    for case in test_cases {
-        assert_eq!(case.2, case.0.powi(case.1));
-    }
-}
+// Mathematical features
+#[cfg(feature = "maths")]
+mod maths {
+    use super::*;
+    use rust_decimal::MathematicalOps;
 
-#[test]
-fn test_sqrt() {
-    let test_cases = &[
-        (Decimal::new(4, 0), Decimal::new(2, 0)),
-        (
-            Decimal::new(3222, 3),
-            Decimal::from_str("1.7949930361981909371487724124").unwrap(),
-        ),
-        (
-            Decimal::new(19945, 2),
-            Decimal::from_str("14.122676800097069416754994263").unwrap(),
-        ),
-        (
-            Decimal::from_str("342.4").unwrap(),
-            Decimal::from_str("18.504053609952604112132102540").unwrap(),
-        ),
-        (
-            Decimal::new(2, 0),
-            Decimal::from_str("1.414213562373095048801688724209698078569671875376948073176").unwrap(),
-        ),
-    ];
-    for case in test_cases {
-        assert_eq!(case.1, case.0.sqrt().unwrap());
+    use num_traits::One;
+
+    #[test]
+    fn test_powi() {
+        let test_cases = &[
+            (Decimal::new(4, 0), 3_u64, Decimal::new(64, 0)),
+            (
+                Decimal::from_str("3.222").unwrap(),
+                5_u64,
+                Decimal::from_str("347.238347228449632").unwrap(),
+            ),
+            (
+                Decimal::from_str("0.1").unwrap(),
+                0_u64,
+                Decimal::from_str("1").unwrap(),
+            ),
+            (
+                Decimal::from_str("342.4").unwrap(),
+                1_u64,
+                Decimal::from_str("342.4").unwrap(),
+            ),
+            (
+                Decimal::from_str("2.0").unwrap(),
+                16_u64,
+                Decimal::from_str("65536").unwrap(),
+            ),
+        ];
+        for case in test_cases {
+            assert_eq!(case.2, case.0.powi(case.1));
+        }
     }
 
-    assert_eq!(Decimal::new(-2, 0).sqrt(), None);
-}
+    #[test]
+    fn test_sqrt() {
+        let test_cases = &[
+            (Decimal::new(4, 0), Decimal::new(2, 0)),
+            (
+                Decimal::new(3222, 3),
+                Decimal::from_str("1.7949930361981909371487724124").unwrap(),
+            ),
+            (
+                Decimal::new(19945, 2),
+                Decimal::from_str("14.122676800097069416754994263").unwrap(),
+            ),
+            (
+                Decimal::from_str("342.4").unwrap(),
+                Decimal::from_str("18.504053609952604112132102540").unwrap(),
+            ),
+            (
+                Decimal::new(2, 0),
+                Decimal::from_str("1.414213562373095048801688724209698078569671875376948073176").unwrap(),
+            ),
+        ];
+        for case in test_cases {
+            assert_eq!(case.1, case.0.sqrt().unwrap());
+        }
 
-#[test]
-fn test_exp() {
-    let test_cases = &[
-        (Decimal::new(10, 0), Decimal::from_str("22023.81992829").unwrap()),
-        (Decimal::new(11, 0), Decimal::from_str("59846.36875797").unwrap()),
-        (Decimal::new(3, 0), Decimal::from_str("20.08553690").unwrap()),
-        (
-            Decimal::from_str("8").unwrap(),
-            Decimal::from_str("2980.94688158").unwrap(),
-        ),
-        (
-            Decimal::from_str("0.1").unwrap(),
-            Decimal::from_str("1.10517092").unwrap(),
-        ),
-        (
-            Decimal::from_str("2.0").unwrap(),
-            Decimal::from_str("7.38905609").unwrap(),
-        ),
-    ];
-    for case in test_cases {
-        assert_eq!(case.1, case.0.exp());
+        assert_eq!(Decimal::new(-2, 0).sqrt(), None);
     }
-}
 
-#[test]
-fn test_exp_with_tolerance() {
-    let test_cases = &[
-        (
-            Decimal::new(10, 0),
-            Decimal::new(3, 2),
-            Decimal::from_str("22023.81992829").unwrap(),
-        ),
-        (
-            Decimal::new(11, 0),
-            Decimal::new(2, 4),
-            Decimal::from_str("59846.36875797").unwrap(),
-        ),
-        (
-            Decimal::new(3, 0),
-            Decimal::new(2, 5),
-            Decimal::from_str("20.08553442").unwrap(),
-        ),
-        (
-            Decimal::from_str("8").unwrap(),
-            Decimal::new(2, 4),
-            Decimal::from_str("2980.94688158").unwrap(),
-        ),
-        (
-            Decimal::from_str("0.1").unwrap(),
-            Decimal::new(2, 4),
-            Decimal::from_str("1.10516667").unwrap(),
-        ),
-        (
-            Decimal::from_str("2.0").unwrap(),
-            Decimal::new(2, 4),
-            Decimal::from_str("7.38904603").unwrap(),
-        ),
-    ];
-    for case in test_cases {
-        assert_eq!(case.2, case.0.exp_with_tolerance(case.1));
+    #[test]
+    fn test_exp() {
+        let test_cases = &[
+            (Decimal::new(10, 0), Decimal::from_str("22023.81992829").unwrap()),
+            (Decimal::new(11, 0), Decimal::from_str("59846.36875797").unwrap()),
+            (Decimal::new(3, 0), Decimal::from_str("20.08553690").unwrap()),
+            (
+                Decimal::from_str("8").unwrap(),
+                Decimal::from_str("2980.94688158").unwrap(),
+            ),
+            (
+                Decimal::from_str("0.1").unwrap(),
+                Decimal::from_str("1.10517092").unwrap(),
+            ),
+            (
+                Decimal::from_str("2.0").unwrap(),
+                Decimal::from_str("7.38905609").unwrap(),
+            ),
+        ];
+        for case in test_cases {
+            assert_eq!(case.1, case.0.exp());
+        }
     }
-}
 
-#[test]
-fn test_norm_cdf() {
-    let test_cases = &[
-        (
-            Decimal::from_str("-0.4").unwrap(),
-            Decimal::from_str("0.3445781286821245037094401728").unwrap(),
-        ),
-        (
-            Decimal::from_str("-0.1").unwrap(),
-            Decimal::from_str("0.4601722899186706579921922711").unwrap(),
-        ),
-        (
-            Decimal::from_str("0.1").unwrap(),
-            Decimal::from_str(either!(
-                "0.5398277100813293420078077289",
-                "0.5398277100813293420078077290"
-            ))
-            .unwrap(),
-        ),
-        (
-            Decimal::from_str("0.4").unwrap(),
-            Decimal::from_str("0.6554218713178754962905598272").unwrap(),
-        ),
-        (
-            Decimal::from_str("2.0").unwrap(),
-            Decimal::from_str("0.9772497381095865280953380672").unwrap(),
-        ),
-    ];
-    for case in test_cases {
-        assert_eq!(case.1, case.0.norm_cdf());
+    #[test]
+    fn test_exp_with_tolerance() {
+        let test_cases = &[
+            (
+                Decimal::new(10, 0),
+                Decimal::new(3, 2),
+                Decimal::from_str("22023.81992829").unwrap(),
+            ),
+            (
+                Decimal::new(11, 0),
+                Decimal::new(2, 4),
+                Decimal::from_str("59846.36875797").unwrap(),
+            ),
+            (
+                Decimal::new(3, 0),
+                Decimal::new(2, 5),
+                Decimal::from_str("20.08553442").unwrap(),
+            ),
+            (
+                Decimal::from_str("8").unwrap(),
+                Decimal::new(2, 4),
+                Decimal::from_str("2980.94688158").unwrap(),
+            ),
+            (
+                Decimal::from_str("0.1").unwrap(),
+                Decimal::new(2, 4),
+                Decimal::from_str("1.10516667").unwrap(),
+            ),
+            (
+                Decimal::from_str("2.0").unwrap(),
+                Decimal::new(2, 4),
+                Decimal::from_str("7.38904603").unwrap(),
+            ),
+        ];
+        for case in test_cases {
+            assert_eq!(case.2, case.0.exp_with_tolerance(case.1));
+        }
     }
-}
 
-#[test]
-fn test_norm_pdf() {
-    let test_cases = &[
-        (
-            Decimal::from_str("-2.0").unwrap(),
-            Decimal::from_str("0.0539909771902348159131327614").unwrap(),
-        ),
-        (
-            Decimal::from_str("-0.4").unwrap(),
-            Decimal::from_str("0.3682701417448470684306485260").unwrap(),
-        ),
-        (
-            Decimal::from_str("-0.1").unwrap(),
-            Decimal::from_str("0.3969525477990849244300670202").unwrap(),
-        ),
-        (
-            Decimal::from_str("0.1").unwrap(),
-            Decimal::from_str("0.3969525477990849244300670202").unwrap(),
-        ),
-        (
-            Decimal::from_str("0.4").unwrap(),
-            Decimal::from_str("0.3682701417448470684306485260").unwrap(),
-        ),
-        (
-            Decimal::from_str("2.0").unwrap(),
-            Decimal::from_str("0.0539909771902348159131327614").unwrap(),
-        ),
-    ];
-    for case in test_cases {
-        assert_eq!(case.1, case.0.norm_pdf());
+    #[test]
+    fn test_norm_cdf() {
+        let test_cases = &[
+            (
+                Decimal::from_str("-0.4").unwrap(),
+                Decimal::from_str("0.3445781286821245037094401728").unwrap(),
+            ),
+            (
+                Decimal::from_str("-0.1").unwrap(),
+                Decimal::from_str("0.4601722899186706579921922711").unwrap(),
+            ),
+            (
+                Decimal::from_str("0.1").unwrap(),
+                Decimal::from_str(either!(
+                    "0.5398277100813293420078077289",
+                    "0.5398277100813293420078077290"
+                ))
+                .unwrap(),
+            ),
+            (
+                Decimal::from_str("0.4").unwrap(),
+                Decimal::from_str("0.6554218713178754962905598272").unwrap(),
+            ),
+            (
+                Decimal::from_str("2.0").unwrap(),
+                Decimal::from_str("0.9772497381095865280953380672").unwrap(),
+            ),
+        ];
+        for case in test_cases {
+            assert_eq!(case.1, case.0.norm_cdf());
+        }
     }
-}
 
-#[test]
-fn test_ln() {
-    let test_cases = &[
-        (Decimal::from_str("1").unwrap(), Decimal::from_str("0").unwrap()),
-        (Decimal::from_str("-2.0").unwrap(), Decimal::from_str("0").unwrap()),
-        (
-            Decimal::from_str("0.23").unwrap(),
-            // Wolfram Alpha gives -1.46968
-            Decimal::from_str(either!(
-                "-1.4661188292208822723626471521",
-                "-1.4661188292208822723626471532"
-            ))
-            .unwrap(),
-        ),
-        (
-            Decimal::from_str("2").unwrap(),
-            // Wolfram Alpha gives 0.693147180559945309417232121458176568075500134360255254120
-            Decimal::from_str(either!(
-                "0.6932271134541528994884316472",
-                "0.6932271134541528994884316422"
-            ))
-            .unwrap(),
-        ),
-        (
-            Decimal::from_str("25").unwrap(),
-            // Wolfram Alpha gives 3.218875824868200749201518666452375279051202708537035443825
-            Decimal::from_str(either!(
-                "3.218876058872673755992392570",
-                "3.218876058872673755992392564"
-            ))
-            .unwrap(),
-        ),
-    ];
-
-    for case in test_cases {
-        assert_eq!(case.1, case.0.ln());
+    #[test]
+    fn test_norm_pdf() {
+        let test_cases = &[
+            (
+                Decimal::from_str("-2.0").unwrap(),
+                Decimal::from_str("0.0539909771902348159131327614").unwrap(),
+            ),
+            (
+                Decimal::from_str("-0.4").unwrap(),
+                Decimal::from_str("0.3682701417448470684306485260").unwrap(),
+            ),
+            (
+                Decimal::from_str("-0.1").unwrap(),
+                Decimal::from_str("0.3969525477990849244300670202").unwrap(),
+            ),
+            (
+                Decimal::from_str("0.1").unwrap(),
+                Decimal::from_str("0.3969525477990849244300670202").unwrap(),
+            ),
+            (
+                Decimal::from_str("0.4").unwrap(),
+                Decimal::from_str("0.3682701417448470684306485260").unwrap(),
+            ),
+            (
+                Decimal::from_str("2.0").unwrap(),
+                Decimal::from_str("0.0539909771902348159131327614").unwrap(),
+            ),
+        ];
+        for case in test_cases {
+            assert_eq!(case.1, case.0.norm_pdf());
+        }
     }
-}
 
-#[test]
-fn test_erf() {
-    let test_cases = &[
-        (
-            Decimal::from_str("-2.0").unwrap(),
-            // Wolfram give -0.9953222650189527
-            Decimal::from_str("-0.9953225170750043399400930073").unwrap(),
-        ),
-        (
-            Decimal::from_str("-0.4").unwrap(),
-            Decimal::from_str("-0.4283924127205154977961931420").unwrap(),
-        ),
-        (
-            Decimal::from_str("0.4").unwrap(),
-            Decimal::from_str("0.4283924127205154977961931420").unwrap(),
-        ),
-        (
-            Decimal::one(),
-            Decimal::from_str("0.8427010463338918630217928957").unwrap(),
-        ),
-        (
-            Decimal::from_str("2").unwrap(),
-            Decimal::from_str("0.9953225170750043399400930073").unwrap(),
-        ),
-    ];
-    for case in test_cases {
-        assert_eq!(case.1, case.0.erf());
+    #[test]
+    fn test_ln() {
+        let test_cases = &[
+            (Decimal::from_str("1").unwrap(), Decimal::from_str("0").unwrap()),
+            (Decimal::from_str("-2.0").unwrap(), Decimal::from_str("0").unwrap()),
+            (
+                Decimal::from_str("0.23").unwrap(),
+                // Wolfram Alpha gives -1.46968
+                Decimal::from_str(either!(
+                    "-1.4661188292208822723626471521",
+                    "-1.4661188292208822723626471532"
+                ))
+                .unwrap(),
+            ),
+            (
+                Decimal::from_str("2").unwrap(),
+                // Wolfram Alpha gives 0.693147180559945309417232121458176568075500134360255254120
+                Decimal::from_str(either!(
+                    "0.6932271134541528994884316472",
+                    "0.6932271134541528994884316422"
+                ))
+                .unwrap(),
+            ),
+            (
+                Decimal::from_str("25").unwrap(),
+                // Wolfram Alpha gives 3.218875824868200749201518666452375279051202708537035443825
+                Decimal::from_str(either!(
+                    "3.218876058872673755992392570",
+                    "3.218876058872673755992392564"
+                ))
+                .unwrap(),
+            ),
+        ];
+
+        for case in test_cases {
+            assert_eq!(case.1, case.0.ln());
+        }
+    }
+
+    #[test]
+    fn test_erf() {
+        let test_cases = &[
+            (
+                Decimal::from_str("-2.0").unwrap(),
+                // Wolfram give -0.9953222650189527
+                Decimal::from_str("-0.9953225170750043399400930073").unwrap(),
+            ),
+            (
+                Decimal::from_str("-0.4").unwrap(),
+                Decimal::from_str("-0.4283924127205154977961931420").unwrap(),
+            ),
+            (
+                Decimal::from_str("0.4").unwrap(),
+                Decimal::from_str("0.4283924127205154977961931420").unwrap(),
+            ),
+            (
+                Decimal::one(),
+                Decimal::from_str("0.8427010463338918630217928957").unwrap(),
+            ),
+            (
+                Decimal::from_str("2").unwrap(),
+                Decimal::from_str("0.9953225170750043399400930073").unwrap(),
+            ),
+        ];
+        for case in test_cases {
+            assert_eq!(case.1, case.0.erf());
+        }
     }
 }
 


### PR DESCRIPTION
To help clean up and make it easier to extend Rust Decimal I'm looking at breaking out all non-critical features as optional features. The first set to be broken out is the `maths` feature which contains mathematical functions such as:
* `ln`
* `exp`
* `pow`
* `norm_cdf`
* etc...

This is broken out in a way which should be easy to migrate to for those using these features by firstly enabling the feature and then, if not using the `prelude` for imports to include: `use rust_decimal::MathematicalOps;`