### PR TITLE
Move declarative sum tests into public test API

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -4363,22 +4363,6 @@ mod test {
     }
 
     #[test]
-    fn declarative_dec_sum() {
-        let vs = (0..10).map(|i| i.into()).collect::<Vec<Decimal>>();
-        let sum: Decimal = vs.iter().cloned().sum();
-
-        assert_eq!(sum, Decimal::from(45))
-    }
-
-    #[test]
-    fn declarative_ref_dec_sum() {
-        let vs = (0..10).map(|i| i.into()).collect::<Vec<Decimal>>();
-        let sum: Decimal = vs.iter().sum();
-
-        assert_eq!(sum, Decimal::from(45))
-    }
-
-    #[test]
     fn test_shl1_internal() {
         struct TestCase {
             // One thing to be cautious of is that the structure of a number here for shifting left is

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -1674,6 +1674,22 @@ fn test_zero_eq_negative_zero() {
     assert!(zero == -zero);
 }
 
+#[test]
+fn declarative_dec_sum() {
+    let vs = (0..10).map(|i| i.into()).collect::<Vec<Decimal>>();
+    let sum: Decimal = vs.iter().cloned().sum();
+
+    assert_eq!(sum, Decimal::from(45))
+}
+
+#[test]
+fn declarative_ref_dec_sum() {
+    let vs = (0..10).map(|i| i.into()).collect::<Vec<Decimal>>();
+    let sum: Decimal = vs.iter().sum();
+
+    assert_eq!(sum, Decimal::from(45))
+}
+
 #[cfg(feature = "postgres")]
 #[test]
 fn to_from_sql() {


### PR DESCRIPTION
This makes refactoring ops easier when trying to speed things up.