### PR TITLE
[docs.rs] Enable all-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [workspace]
 members = [".", "./macros"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Some methods vanished from `docs.rs` as they are now optional.