### PR TITLE
Add `from_i128_with_scale_rslt` 

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -218,7 +218,6 @@ impl Decimal {
     /// let max = Decimal::from_i128_with_scale_rslt(i128::MAX, u32::MAX);
     /// assert!(max.is_err());
     /// ```
-    #[must_use]
     pub fn from_i128_with_scale_rslt(num: i128, scale: u32) -> crate::Result<Decimal> {
         if scale > MAX_PRECISION {
             return Err(Error::ScaleExceedsMaximumPrecision(scale));

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -196,7 +196,7 @@ impl Decimal {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust
     /// use rust_decimal::Decimal;
     ///
     /// let pi = Decimal::from_i128_with_scale(3141i128, 3);
@@ -204,29 +204,42 @@ impl Decimal {
     /// ```
     #[must_use]
     pub fn from_i128_with_scale(num: i128, scale: u32) -> Decimal {
+        Self::from_i128_with_scale_rslt(num, scale).unwrap()
+    }
+
+    /// Checked version of `from_i128_with_scale`. Will return `Err` instead
+    /// of panicking at run-time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rust_decimal::Decimal;
+    ///
+    /// let max = Decimal::from_i128_with_scale_rslt(i128::MAX, u32::MAX);
+    /// assert!(max.is_err());
+    /// ```
+    #[must_use]
+    pub fn from_i128_with_scale_rslt(num: i128, scale: u32) -> crate::Result<Decimal> {
         if scale > MAX_PRECISION {
-            panic!(
-                "Scale exceeds the maximum precision allowed: {} > {}",
-                scale, MAX_PRECISION
-            );
+            return Err(Error::ScaleExceedsMaximumPrecision(scale));
         }
         let mut neg = false;
         let mut wrapped = num;
         if num > MAX_I128_REPR {
-            panic!("Number exceeds maximum value that can be represented");
+            return Err(Error::ExceedsMaximumPossibleValue(num));
         } else if num < -MAX_I128_REPR {
-            panic!("Number less than minimum value that can be represented");
+            return Err(Error::LessThanMinimumPossibleValue(num));
         } else if num < 0 {
             neg = true;
             wrapped = -num;
         }
         let flags: u32 = flags(neg, scale);
-        Decimal {
+        Ok(Decimal {
             flags,
             lo: (wrapped as u64 & U32_MASK) as u32,
             mid: ((wrapped as u64 >> 32) & U32_MASK) as u32,
             hi: ((wrapped as u128 >> 64) as u64 & U32_MASK) as u32,
-        }
+        })
     }
 
     /// Returns a `Decimal` using the instances constituent parts.
@@ -304,17 +317,17 @@ impl Decimal {
         let err_msg = "Failed to parse";
         let mut split = value.splitn(2, |c| c == 'e' || c == 'E');
 
-        let base = split.next().ok_or_else(|| Error::new(err_msg))?;
-        let exp = split.next().ok_or_else(|| Error::new(err_msg))?;
+        let base = split.next().ok_or_else(|| Error::from(err_msg))?;
+        let exp = split.next().ok_or_else(|| Error::from(err_msg))?;
 
         let mut ret = Decimal::from_str(base)?;
         let current_scale = ret.scale();
 
         if let Some(stripped) = exp.strip_prefix('-') {
-            let exp: u32 = stripped.parse().map_err(|_| Error::new(err_msg))?;
+            let exp: u32 = stripped.parse().map_err(|_| Error::from(err_msg))?;
             ret.set_scale(current_scale + exp)?;
         } else {
-            let exp: u32 = exp.parse().map_err(|_| Error::new(err_msg))?;
+            let exp: u32 = exp.parse().map_err(|_| Error::from(err_msg))?;
             if exp <= current_scale {
                 ret.set_scale(current_scale - exp)?;
             } else {
@@ -458,7 +471,7 @@ impl Decimal {
     /// ```
     pub fn set_scale(&mut self, scale: u32) -> Result<(), Error> {
         if scale > MAX_PRECISION {
-            return Err(Error::new("Scale exceeds maximum precision"));
+            return Err(Error::from("Scale exceeds maximum precision"));
         }
         self.flags = (scale << SCALE_SHIFT) | (self.flags & SIGN_MASK);
         Ok(())
@@ -1698,7 +1711,7 @@ impl core::convert::TryFrom<f32> for Decimal {
     type Error = crate::Error;
 
     fn try_from(value: f32) -> Result<Self, Error> {
-        Self::from_f32(value).ok_or_else(|| Error::new("Failed to convert to Decimal"))
+        Self::from_f32(value).ok_or_else(|| Error::from("Failed to convert to Decimal"))
     }
 }
 
@@ -1706,7 +1719,7 @@ impl core::convert::TryFrom<f64> for Decimal {
     type Error = crate::Error;
 
     fn try_from(value: f64) -> Result<Self, Error> {
-        Self::from_f64(value).ok_or_else(|| Error::new("Failed to convert to Decimal"))
+        Self::from_f64(value).ok_or_else(|| Error::from("Failed to convert to Decimal"))
     }
 }
 
@@ -1714,7 +1727,7 @@ impl core::convert::TryFrom<Decimal> for f32 {
     type Error = crate::Error;
 
     fn try_from(value: Decimal) -> Result<Self, Self::Error> {
-        Decimal::to_f32(&value).ok_or_else(|| Error::new("Failed to convert to f32"))
+        Decimal::to_f32(&value).ok_or_else(|| Error::from("Failed to convert to f32"))
     }
 }
 
@@ -1722,7 +1735,7 @@ impl core::convert::TryFrom<Decimal> for f64 {
     type Error = crate::Error;
 
     fn try_from(value: Decimal) -> Result<Self, Self::Error> {
-        Decimal::to_f64(&value).ok_or_else(|| Error::new("Failed to convert to f64"))
+        Decimal::to_f64(&value).ok_or_else(|| Error::from("Failed to convert to f64"))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,33 +1,46 @@
+use crate::constants::{MAX_I128_REPR, MAX_PRECISION};
 use alloc::string::String;
 use core::fmt;
 
 /// Error type for the library.
 #[derive(Clone, Debug)]
-pub struct Error {
-    message: String,
+pub enum Error {
+    ErrorString(String),
+    ExceedsMaximumPossibleValue(i128),
+    LessThanMinimumPossibleValue(i128),
+    ScaleExceedsMaximumPrecision(u32),
 }
 
-impl Error {
-    /// Instantiate an error with the specified error message.
-    ///
-    /// This function is only available within the crate as there should never
-    /// be a need to create this error outside of the library.
-    pub(crate) fn new<S: Into<String>>(message: S) -> Error {
-        Error {
-            message: message.into(),
-        }
+impl<S> From<S> for Error
+where
+    S: Into<String>,
+{
+    #[inline]
+    fn from(from: S) -> Self {
+        Self::ErrorString(from.into())
     }
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        &self.message
-    }
-}
+impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        f.pad(&self.message)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::ErrorString(ref err) => f.pad(&err),
+            Self::ExceedsMaximumPossibleValue(ref num) => write!(
+                f,
+                "Number exceeds maximum value that can be represented: {} > {}",
+                num, MAX_I128_REPR
+            ),
+            Self::LessThanMinimumPossibleValue(ref num) => write!(
+                f,
+                "Number less than minimum value that can be represented: {} < {}",
+                num, -MAX_I128_REPR
+            ),
+            Self::ScaleExceedsMaximumPrecision(ref scale) => {
+                write!(f, "Scale exceeds maximum precision: {} > {}", scale, MAX_PRECISION)
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,3 +160,7 @@ pub mod prelude {
 #[cfg(feature = "diesel")]
 #[macro_use]
 extern crate diesel;
+
+/// Shortcut for `core::result::Result<T, rust_decimal::Error>`. Useful to distinguish
+/// between `rust_decimal` and `std` types.
+pub type Result<T> = core::result::Result<T, Error>;

--- a/src/str.rs
+++ b/src/str.rs
@@ -113,7 +113,7 @@ pub(crate) fn fmt_scientific_notation(
 // dedicated implementation for the most common case.
 pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
     if str.is_empty() {
-        return Err(Error::new("Invalid decimal: empty"));
+        return Err(Error::from("Invalid decimal: empty"));
     }
 
     let mut offset = 0;
@@ -153,7 +153,7 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
             }
             b'.' => {
                 if digits_before_dot >= 0 {
-                    return Err(Error::new("Invalid decimal: two decimal points"));
+                    return Err(Error::from("Invalid decimal: two decimal points"));
                 }
                 digits_before_dot = coeff.len() as i32;
                 offset += 1;
@@ -162,12 +162,12 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
             b'_' => {
                 // Must start with a number...
                 if coeff.is_empty() {
-                    return Err(Error::new("Invalid decimal: must start lead with a number"));
+                    return Err(Error::from("Invalid decimal: must start lead with a number"));
                 }
                 offset += 1;
                 len -= 1;
             }
-            _ => return Err(Error::new("Invalid decimal: unknown character")),
+            _ => return Err(Error::from("Invalid decimal: unknown character")),
         }
     }
 
@@ -180,11 +180,11 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
             b'.' => {
                 // Still an error if we have a second dp
                 if digits_before_dot >= 0 {
-                    return Err(Error::new("Invalid decimal: two decimal points"));
+                    return Err(Error::from("Invalid decimal: two decimal points"));
                 }
                 0
             }
-            _ => return Err(Error::new("Invalid decimal: unknown character")),
+            _ => return Err(Error::from("Invalid decimal: unknown character")),
         };
 
         // Round at midpoint
@@ -211,7 +211,7 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
 
     // here when no characters left
     if coeff.is_empty() {
-        return Err(Error::new("Invalid decimal: no digits found"));
+        return Err(Error::from("Invalid decimal: no digits found"));
     }
 
     let mut scale = if digits_before_dot >= 0 {
@@ -235,20 +235,20 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
             // This may or may not be an issue - depending on whether we're past a decimal point
             // or not.
             if (i as i32) < digits_before_dot && i + 1 < len {
-                return Err(Error::new("Invalid decimal: overflow from too many digits"));
+                return Err(Error::from("Invalid decimal: overflow from too many digits"));
             }
 
             if *digit >= 5 {
                 let carry = add_one_internal(&mut data);
                 if carry > 0 {
                     // Highly unlikely scenario which is more indicative of a bug
-                    return Err(Error::new("Invalid decimal: overflow when rounding"));
+                    return Err(Error::from("Invalid decimal: overflow when rounding"));
                 }
             }
             // We're also one less digit so reduce the scale
             let diff = (len - i) as u32;
             if diff > scale {
-                return Err(Error::new("Invalid decimal: overflow from scale mismatch"));
+                return Err(Error::from("Invalid decimal: overflow from scale mismatch"));
             }
             scale -= diff;
             break;
@@ -259,7 +259,7 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
             let carry = add_by_internal(&mut data, &[*digit]);
             if carry > 0 {
                 // Highly unlikely scenario which is more indicative of a bug
-                return Err(Error::new("Invalid decimal: overflow from carry"));
+                return Err(Error::from("Invalid decimal: overflow from carry"));
             }
         }
     }
@@ -269,14 +269,14 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
 
 pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate::Error> {
     if str.is_empty() {
-        return Err(Error::new("Invalid decimal: empty"));
+        return Err(Error::from("Invalid decimal: empty"));
     }
     if radix < 2 {
-        return Err(Error::new("Unsupported radix < 2"));
+        return Err(Error::from("Unsupported radix < 2"));
     }
     if radix > 36 {
         // As per trait documentation
-        return Err(Error::new("Unsupported radix > 36"));
+        return Err(Error::from("Unsupported radix > 36"));
     }
 
     let mut offset = 0;
@@ -346,7 +346,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
         34 => 19,
         35 => 19,
         36 => 19,
-        _ => return Err(Error::new("Unsupported radix")),
+        _ => return Err(Error::from("Unsupported radix")),
     };
 
     let mut maybe_round = false;
@@ -355,7 +355,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
         match b {
             b'0'..=b'9' => {
                 if b > max_n {
-                    return Err(Error::new("Invalid decimal: invalid character"));
+                    return Err(Error::from("Invalid decimal: invalid character"));
                 }
                 coeff.push(u32::from(b - b'0'));
                 offset += 1;
@@ -369,7 +369,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             }
             b'a'..=b'z' => {
                 if b > max_alpha_lower {
-                    return Err(Error::new("Invalid decimal: invalid character"));
+                    return Err(Error::from("Invalid decimal: invalid character"));
                 }
                 coeff.push(u32::from(b - b'a') + 10);
                 offset += 1;
@@ -382,7 +382,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             }
             b'A'..=b'Z' => {
                 if b > max_alpha_upper {
-                    return Err(Error::new("Invalid decimal: invalid character"));
+                    return Err(Error::from("Invalid decimal: invalid character"));
                 }
                 coeff.push(u32::from(b - b'A') + 10);
                 offset += 1;
@@ -395,7 +395,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             }
             b'.' => {
                 if digits_before_dot >= 0 {
-                    return Err(Error::new("Invalid decimal: two decimal points"));
+                    return Err(Error::from("Invalid decimal: two decimal points"));
                 }
                 digits_before_dot = coeff.len() as i32;
                 offset += 1;
@@ -404,12 +404,12 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             b'_' => {
                 // Must start with a number...
                 if coeff.is_empty() {
-                    return Err(Error::new("Invalid decimal: must start lead with a number"));
+                    return Err(Error::from("Invalid decimal: must start lead with a number"));
                 }
                 offset += 1;
                 len -= 1;
             }
-            _ => return Err(Error::new("Invalid decimal: unknown character")),
+            _ => return Err(Error::from("Invalid decimal: unknown character")),
         }
     }
 
@@ -419,19 +419,19 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
         let digit = match next_byte {
             b'0'..=b'9' => {
                 if next_byte > max_n {
-                    return Err(Error::new("Invalid decimal: invalid character"));
+                    return Err(Error::from("Invalid decimal: invalid character"));
                 }
                 u32::from(next_byte - b'0')
             }
             b'a'..=b'z' => {
                 if next_byte > max_alpha_lower {
-                    return Err(Error::new("Invalid decimal: invalid character"));
+                    return Err(Error::from("Invalid decimal: invalid character"));
                 }
                 u32::from(next_byte - b'a') + 10
             }
             b'A'..=b'Z' => {
                 if next_byte > max_alpha_upper {
-                    return Err(Error::new("Invalid decimal: invalid character"));
+                    return Err(Error::from("Invalid decimal: invalid character"));
                 }
                 u32::from(next_byte - b'A') + 10
             }
@@ -439,11 +439,11 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             b'.' => {
                 // Still an error if we have a second dp
                 if digits_before_dot >= 0 {
-                    return Err(Error::new("Invalid decimal: two decimal points"));
+                    return Err(Error::from("Invalid decimal: two decimal points"));
                 }
                 0
             }
-            _ => return Err(Error::new("Invalid decimal: unknown character")),
+            _ => return Err(Error::from("Invalid decimal: unknown character")),
         };
 
         // Round at midpoint
@@ -471,7 +471,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
 
     // here when no characters left
     if coeff.is_empty() {
-        return Err(Error::new("Invalid decimal: no digits found"));
+        return Err(Error::from("Invalid decimal: no digits found"));
     }
 
     let mut scale = if digits_before_dot >= 0 {
@@ -496,20 +496,20 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             // This may or may not be an issue - depending on whether we're past a decimal point
             // or not.
             if (i as i32) < digits_before_dot && i + 1 < len {
-                return Err(Error::new("Invalid decimal: overflow from too many digits"));
+                return Err(Error::from("Invalid decimal: overflow from too many digits"));
             }
 
             if *digit >= 5 {
                 let carry = add_one_internal(&mut data);
                 if carry > 0 {
                     // Highly unlikely scenario which is more indicative of a bug
-                    return Err(Error::new("Invalid decimal: overflow when rounding"));
+                    return Err(Error::from("Invalid decimal: overflow when rounding"));
                 }
             }
             // We're also one less digit so reduce the scale
             let diff = (len - i) as u32;
             if diff > scale {
-                return Err(Error::new("Invalid decimal: overflow from scale mismatch"));
+                return Err(Error::from("Invalid decimal: overflow from scale mismatch"));
             }
             scale -= diff;
             break;
@@ -520,7 +520,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             let carry = add_by_internal(&mut data, &[*digit]);
             if carry > 0 {
                 // Highly unlikely scenario which is more indicative of a bug
-                return Err(Error::new("Invalid decimal: overflow from carry"));
+                return Err(Error::from("Invalid decimal: overflow from carry"));
             }
         }
     }


### PR DESCRIPTION
@paupino Feel free to close this PR if the changes aren't desirable.

My use-case: External stream of bytes that represent `i128` decimals are received but can't be trusted so a check is necessary to ensure correctness and recovery. With `from_i128_with_scale`, the binary will simply halt execution as there is currently no way to verify if `i128` or `u32` are valid, thus the creation of `from_i128_with_scale_rslt`.