### PR TITLE
Fixes an issue whereby rounding small negative numbers towards zero would cause negativity to be retained

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -964,12 +964,7 @@ impl Decimal {
             RoundingStrategy::RoundDown | RoundingStrategy::ToZero => (),
         }
 
-        Decimal {
-            lo: value[0],
-            mid: value[1],
-            hi: value[2],
-            flags: flags(negative, dp),
-        }
+        Decimal::from_parts(value[0], value[1], value[2], negative, dp)
     }
 
     /// Returns a new `Decimal` number with the specified number of decimal points for fractional portion.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -309,4 +309,21 @@ mod test {
             assert_eq!(8usize, encoded.len());
         }
     }
+
+    #[test]
+    #[cfg(all(feature = "serde-str", not(feature = "serde-float")))]
+    fn bincode_nested_serialization() {
+        // Issue #361
+        #[derive(Deserialize, Serialize, Debug)]
+        pub struct Foo {
+            value: Decimal,
+        }
+
+        let s = Foo {
+            value: Decimal::new(-1, 3).round_dp(0),
+        };
+        let ser = bincode::serialize(&s).unwrap();
+        let des: Foo = bincode::deserialize(&ser).unwrap();
+        assert_eq!(des.value, s.value);
+    }
 }


### PR DESCRIPTION
Fixes #361 

This ensures zero remains consistently `0`.