### PR TITLE
Add c-repr feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ serde-str = ["serde"]
 serde-arbitrary-precision = ["serde", "serde_json/arbitrary_precision"]
 std = ["arrayvec/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
+c-repr = [] # Force Decimal to be repr(C)
 
 [workspace]
 members = [".", "./macros"]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -71,6 +71,7 @@ pub struct UnpackedDecimal {
 /// between 0 and 28 inclusive.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
+#[cfg_attr(feature = "c-repr", repr(C))]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -17,6 +17,12 @@ macro_rules! either {
 }
 
 #[test]
+#[cfg(feature = "c-repr")]
+fn layout_is_correct() {
+    assert_eq!(std::mem::size_of::<Decimal>(), std::mem::size_of::<u128>());
+}
+
+#[test]
 fn it_can_extract_the_mantissa() {
     let tests = [
         ("1", 1i128, 0),


### PR DESCRIPTION
This adds the c-repr feature which forces `Decimal` to be #[repr(C)].

Closes https://github.com/paupino/rust-decimal/issues/359.