### PR TITLE
Add fuzz targets to exercize checked functions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,8 @@ jobs:
           profile: minimal
           toolchain: nightly
 
+      - uses: davidB/rust-cargo-make@v1
+
       - uses: actions-rs/install@v0.1
         with:
           crate: cargo-fuzz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
           crate: cargo-fuzz
           use-tool-cache: true
 
-      - name: Run macro tests
+      - name: Run fuzz tests
         uses: actions-rs/cargo@v1
         with:
           command: make

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,6 +144,31 @@ jobs:
           command: clippy
           args: --workspace --all-features
 
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          override: true
+          profile: minimal
+          toolchain: nightly
+
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-fuzz
+          use-tool-cache: true
+
+      - name: Run macro tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: fuzz
+
   minimum_rust_version:
     name: Check minimum rust version
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ Cargo.lock
 
 # IDE support
 .idea/
+
+# Fuzz
+artifacts
+corpus
+target

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,9 @@
 [config]
 default_to_workspace = false
 
+[env]
+FUZZ_RUNS = 10000000
+
 [tasks.build]
 command = "cargo"
 args = ["build"]
@@ -70,6 +73,24 @@ workspace = true
 install_crate = "rustfmt"
 command = "cargo"
 args = ["fmt", "--", "--emit=files"]
+
+[tasks.fuzz]
+dependencies = [
+    "fuzz-arithmetic",
+    "fuzz-constructors"
+]
+
+[tasks.fuzz-arithmetic]
+toolchain = "nightly"
+install_crate = "cargo-fuzz"
+command = "cargo"
+args = ["fuzz", "run", "arithmetic", "--", "-runs=${FUZZ_RUNS}"]
+
+[tasks.fuzz-constructors]
+toolchain = "nightly"
+install_crate = "cargo-fuzz"
+command = "cargo"
+args = ["fuzz", "run", "constructors", "--", "-runs=${FUZZ_RUNS}"]
 
 [tasks.outdated]
 install_crate = "cargo-outdated"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+[[bin]]
+doc = false
+name = "arithmetic"
+path = "fuzz_targets/arithmetic.rs"
+test = false
+
+[[bin]]
+doc = false
+name = "constructors"
+path = "fuzz_targets/constructors.rs"
+test = false
+
+[dependencies]
+arbitrary = { features = ["derive"], version = "1.0" }
+libfuzzer-sys = "0.4"
+rust_decimal = { features = ["maths", "rust-fuzz"], path = ".." }
+
+[package]
+authors = ["Automatically generated"]
+edition = "2018"
+name = "rust-decimal-fuzz"
+publish = false
+version = "0.0.0"
+
+[package.metadata]
+cargo-fuzz = true
+
+[workspace]
+members = ["."]

--- a/fuzz/fuzz_targets/arithmetic.rs
+++ b/fuzz/fuzz_targets/arithmetic.rs
@@ -1,0 +1,31 @@
+#![no_main]
+
+use rust_decimal::{Decimal, MathematicalOps};
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct Data {
+    a: Decimal,
+    b: Decimal,
+    exp_f64: f64,
+    exp_i64: i64,
+    exp_u64: u64,
+}
+
+libfuzzer_sys::fuzz_target!(|data: Data| {
+    let fun = || {
+        let _ = data.a.checked_add(data.b)?;
+        let _ = data.a.checked_div(data.b)?;
+        //let _ = data.a.checked_exp_with_tolerance(data.b)?;
+        //let _ = data.a.checked_exp()?;
+        //let _ = data.a.checked_mul(data.b)?;
+        //let _ = data.a.checked_norm_pdf()?;
+        //let _ = data.a.checked_powd(data.b)?;
+        //let _ = data.a.checked_powf(data.exp_f64)?;
+        //let _ = data.a.checked_powi(data.exp_i64)?;
+        //let _ = data.a.checked_powu(data.exp_u64)?;
+        //let _ = data.a.checked_sub(data.b)?;
+
+        Some(())
+    };
+    let _ = fun();
+});

--- a/fuzz/fuzz_targets/constructors.rs
+++ b/fuzz/fuzz_targets/constructors.rs
@@ -1,0 +1,22 @@
+#![no_main]
+
+use rust_decimal::Decimal;
+
+#[derive(Debug, arbitrary::Arbitrary)]
+struct Data<'a> {
+    from_scientific_value: &'a str,
+
+    try_from_i128_with_scale_num: i128,
+    try_from_i128_with_scale_scale: u32,
+
+    try_new_num: i64,
+    try_new_scale: u32,
+}
+
+libfuzzer_sys::fuzz_target!(|data: Data<'_>| {
+    let _ = Decimal::from_scientific(data.from_scientific_value);
+
+    let _ = Decimal::try_from_i128_with_scale(data.try_from_i128_with_scale_num, data.try_from_i128_with_scale_scale);
+
+    let _ = Decimal::try_new(data.try_new_num, data.try_new_scale);
+});

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,11 @@ impl fmt::Display for Error {
                 write!(f, "Number less than minimum value that can be represented.")
             }
             Self::ScaleExceedsMaximumPrecision(ref scale) => {
-                write!(f, "Scale exceeds maximum precision: {} > {}", scale, MAX_PRECISION)
+                write!(
+                    f,
+                    "Scale exceeds the maximum precision allowed: {} > {}",
+                    scale, MAX_PRECISION
+                )
             }
         }
     }


### PR DESCRIPTION
Useful to catch user inputs that could abort thread execution like #376.

* Adds limited CI execution through a script that can also be used for local development.
* Constify some methods
* Creates a new `try_new` method for convenience.
* Adds initial `constructors`, `add_and_sub` and `div_and_mul` targets (more yet to come).

CI is purposely failing because things like:
```rust
let a = X;
let b = Y;

let c = a / b;

assert_eq!(c * b, a);
```
Are currently being used, which brings rounding errors like:
```
left: `127.99999999986666197612373336`
right: `128`
```
If it is a normal behaviour (probably is), then the above code snippet can be replaced by:
```rust
let a = X;
let b = Y;

let _c = a / b;
let _d = a * b;
```