### PR TITLE
fix panic in call to Decimal::ZERO.ln()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "rust_decimal"
 readme = "./README.md"
 repository = "https://github.com/paupino/rust-decimal"
-version = "1.14.2"
+version = "1.14.3"
 exclude = [ "tests/generated/*" ]
 
 [package.metadata.docs.rs]

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,10 @@
 # Version History
 
+## 1.14.3
+
+Fixes an issue[#398](https://github.com/paupino/rust-decimal/issues/398) where `Decimal::ZERO.ln()` would panic rather than returning `Decimal::ZERO`. This 
+aligns the behavior with calling `ln` on negative decimals.
+
 ## 1.14.2
 
 Fixes an overflow issue during division under some specific circumstances. ([#392](https://github.com/paupino/rust-decimal/issues/392))

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -325,7 +325,7 @@ impl MathematicalOps for Decimal {
         const C256: Decimal = Decimal::from_parts_raw(256, 0, 0, 0);
         const EIGHT_LN2: Decimal = Decimal::from_parts(1406348788, 262764557, 3006046716, false, 28);
 
-        if self.is_sign_positive() {
+        if self.is_sign_positive() && !self.is_zero() {
             if *self == Decimal::ONE {
                 Decimal::ZERO
             } else {

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3537,6 +3537,7 @@ mod maths {
     fn test_ln() {
         let test_cases = &[
             (Decimal::from_str("1").unwrap(), Decimal::from_str("0").unwrap()),
+            (Decimal::from_str("0").unwrap(), Decimal::from_str("0").unwrap()),
             (Decimal::from_str("-2.0").unwrap(), Decimal::from_str("0").unwrap()),
             (
                 Decimal::from_str("0.23").unwrap(),


### PR DESCRIPTION
Fixes https://github.com/paupino/rust-decimal/issues/398

I wasn't sure whether to write the `VERSION.md` update myself or not - of course feel free to update the language as you see fit.
