### PR TITLE
Round f64 before final conversion in to_f64

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1841,7 +1841,7 @@ impl ToPrimitive for Decimal {
             let frac_f64 = (frac_part as f64) / (precision as f64);
             let value = sign * ((integral_part as f64) + frac_f64);
             let round_to = 10f64.powi(self.scale() as i32);
-            Some(value * round_to / round_to)
+            Some((value * round_to).round() / round_to)
         }
     }
 }

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -2457,6 +2457,9 @@ fn it_converts_to_f64() {
             None, // Cannot be represented in an f64
         ),
         ("1.59283191", Some(1.59283191_f64)),
+        ("2.2238", Some(2.2238_f64)),
+        ("2.2238123", Some(2.2238123_f64)),
+        ("22238", Some(22238_f64)),
     ];
     for &(value, expected) in tests {
         let value = Decimal::from_str(value).unwrap().to_f64();


### PR DESCRIPTION
This fixes the issue described in #401 by rounding the `f64` before attempting to reduce precision.