### PR TITLE
Enable all fuzz tests

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,7 +2,7 @@
 default_to_workspace = false
 
 [env]
-FUZZ_RUNS = 10000000
+FUZZ_RUNS = 1000
 
 [tasks.build]
 command = "cargo"

--- a/fuzz/fuzz_targets/arithmetic.rs
+++ b/fuzz/fuzz_targets/arithmetic.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, MathematicalOps};
 
 #[derive(Debug, arbitrary::Arbitrary)]
 struct Data {
@@ -14,13 +14,13 @@ struct Data {
 libfuzzer_sys::fuzz_target!(|data: Data| {
     let _ = data.a.checked_add(data.b);
     let _ = data.a.checked_div(data.b);
-    //let _ = data.a.checked_exp_with_tolerance(data.b);
-    //let _ = data.a.checked_exp();
-    //let _ = data.a.checked_mul(data.b);
-    //let _ = data.a.checked_norm_pdf();
-    //let _ = data.a.checked_powd(data.b);
-    //let _ = data.a.checked_powf(data.exp_f64);
-    //let _ = data.a.checked_powi(data.exp_i64);
-    //let _ = data.a.checked_powu(data.exp_u64);
-    //let _ = data.a.checked_sub(data.b);
+    let _ = data.a.checked_exp_with_tolerance(data.b);
+    let _ = data.a.checked_exp();
+    let _ = data.a.checked_mul(data.b);
+    let _ = data.a.checked_norm_pdf();
+    let _ = data.a.checked_powd(data.b);
+    let _ = data.a.checked_powf(data.exp_f64);
+    let _ = data.a.checked_powi(data.exp_i64);
+    let _ = data.a.checked_powu(data.exp_u64);
+    let _ = data.a.checked_sub(data.b);
 });

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -155,7 +155,7 @@ impl MathematicalOps for Decimal {
         }
 
         let mut term = *self;
-        let mut result = self + Decimal::ONE;
+        let mut result = self.checked_add(Decimal::ONE)?;
 
         for factorial in FACTORIAL.iter().skip(2) {
             term = self.checked_mul(term)?;


### PR DESCRIPTION
After running for a while, no panic occurred so it seems that `let mut result = self + Decimal::ONE;` was the sole culprit.
It is worth noting that although no panic occurred on my local tests and no panic can occur after running the fuzz targets for many years, all explicit arithmetic operator (`+`, `*`, `-`, `%`, etc) should be audited to catch any possible corner-case.