### PR TITLE
Add benchmarks to compare different structures 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,21 @@
+[[bench]]
+harness = false
+name = "libraries"
+path = "benches/libraries.rs"
+
 [package]
 authors = ["Paul Mason <paul@form1.co.nz>"]
 categories = ["science","data-structures"]
 description = "A Decimal Implementation written in pure Rust suitable for financial calculations."
 documentation = "https://docs.rs/rust_decimal/"
 edition = "2018"
+exclude = [ "tests/generated/*" ]
 keywords = ["decimal","financial","fixed","precision"]
 license = "MIT"
 name = "rust_decimal"
 readme = "./README.md"
 repository = "https://github.com/paupino/rust-decimal"
 version = "1.15.0"
-exclude = [ "tests/generated/*" ]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -28,10 +33,14 @@ serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
 
 [dev-dependencies]
+bigdecimal = { default-features = false, version = "0.2" }
 bincode = "1.3"
 bytes = "1.0"
+criterion = { default-features = false, version = "0.3" }
 csv = "1"
+decimal_rs = { default-features = false, package = "decimal", version = "2.0" }
 futures = "0.3"
+rust_decimal_macros = { path = "macros" }
 serde_derive = "1.0"
 serde_json = "1.0"
 tokio = { features = ["rt-multi-thread", "test-util", "macros"], version = "1.0" }
@@ -46,10 +55,10 @@ legacy-ops = []
 maths = []
 maths-nopanic = ["maths"]
 rust-fuzz = ["arbitrary"]
+serde-arbitrary-precision = ["serde", "serde_json/arbitrary_precision"]
 serde-bincode = ["serde-str"] # Backwards compatability
 serde-float = ["serde"]
 serde-str = ["serde"]
-serde-arbitrary-precision = ["serde", "serde_json/arbitrary_precision"]
 std = ["arrayvec/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 

--- a/benches/libraries.rs
+++ b/benches/libraries.rs
@@ -1,0 +1,57 @@
+use core::str::FromStr;
+use criterion::{
+    black_box, criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId, Criterion,
+};
+
+macro_rules! add_benchmark_group {
+    ($criterion:expr, $f:ident, $op:tt) => {
+        fn $f<M, const N: usize>(group: &mut BenchmarkGroup<'_, M>)
+        where
+        M: Measurement,
+        {
+            group.bench_with_input(BenchmarkId::new("bigdecimal", N), &N, |ben, _| {
+                let a = bigdecimal::BigDecimal::from_str("2.01").unwrap();
+                let b = bigdecimal::BigDecimal::from_str("2.01").unwrap();
+                ben.iter(|| black_box(a.clone() $op b.clone()))
+            });
+
+            group.bench_with_input(BenchmarkId::new("decimal-rs", N), &N, |ben, _| {
+                let a = decimal_rs::d128!(2.01);
+                let b = decimal_rs::d128!(2.01);
+                ben.iter(|| black_box(a $op b))
+            });
+
+            group.bench_with_input(BenchmarkId::new("f32", N), &N, |ben, _| {
+                let a = 2.01f32;
+                let b = 2.01f32;
+                ben.iter(|| black_box(a $op b))
+            });
+
+            group.bench_with_input(BenchmarkId::new("f64", N), &N, |ben, _| {
+                let a = 2.01f64;
+                let b = 2.01f64;
+                ben.iter(|| black_box(a $op b))
+            });
+
+            group.bench_with_input(BenchmarkId::new("rust-decimal", N), &N, |ben, _| {
+                let a = rust_decimal_macros::dec!(2.01);
+                let b = rust_decimal_macros::dec!(2.01);
+                ben.iter(|| black_box(a $op b))
+            });
+        }
+
+        let mut group = $criterion.benchmark_group(stringify!($f));
+        $f::<_, 100>(&mut group);
+        group.finish();
+    };
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    add_benchmark_group!(c, addition, +);
+    add_benchmark_group!(c, division, /);
+    add_benchmark_group!(c, multiplication, *);
+    add_benchmark_group!(c, subtraction, -);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Useful to see how `rust-decimal` is performing compared to other libraries or how much is lagging behind `f32` or `f64` hardware based operations.

![addition](https://user-images.githubusercontent.com/17877264/129458061-82c68e19-3cf0-48a2-be0d-a1c70ed7ab46.jpg)
![division](https://user-images.githubusercontent.com/17877264/129458091-cf613144-bdbc-47dc-9848-4ec4bbf719d4.jpg)
![subtration](https://user-images.githubusercontent.com/17877264/129458100-b938c42e-47da-4036-9b5c-75c0ca2209cd.jpg)
![multiplication](https://user-images.githubusercontent.com/17877264/129458110-a9ec31a1-fa48-4730-b835-d829bf3cbd27.jpg)

As seen from above, `rust-decimal` is the fastest decimal library with operations ~2000% slower if compared to native primitives.