### PR TITLE
Remove unecessary arrayvec feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ serde-arbitrary-precision = ["serde", "serde_json/arbitrary_precision"]
 serde-bincode = ["serde-str"] # Backwards compatability
 serde-float = ["serde"]
 serde-str = ["serde"]
-std = ["arrayvec/std"]
+std = []
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [workspace]


### PR DESCRIPTION
`rust-decimal` does not use any features provided by the `std` flag of `arrayvec`, therefore, unnecessary .