### PR TITLE
Add more fuzz tests

### DIFF
--- a/fuzz/fuzz_targets/arithmetic.rs
+++ b/fuzz/fuzz_targets/arithmetic.rs
@@ -13,6 +13,7 @@ struct Data {
 
 libfuzzer_sys::fuzz_target!(|data: Data| {
     let _ = data.a.checked_add(data.b);
+    let _ = data.a.checked_cos();
     let _ = data.a.checked_div(data.b);
     let _ = data.a.checked_exp_with_tolerance(data.b);
     let _ = data.a.checked_exp();
@@ -22,5 +23,7 @@ libfuzzer_sys::fuzz_target!(|data: Data| {
     let _ = data.a.checked_powf(data.exp_f64);
     let _ = data.a.checked_powi(data.exp_i64);
     let _ = data.a.checked_powu(data.exp_u64);
+    let _ = data.a.checked_sin();
     let _ = data.a.checked_sub(data.b);
+    let _ = data.a.checked_tan();
 });


### PR DESCRIPTION
https://github.com/paupino/rust-decimal/blob/1e35a73e7650f99abfa2bf0dceb49b41a092239c/src/maths.rs#L536-L542

```rust
#[test]
fn test() {
    use core::str::FromStr;
    let n = crate::Decimal::from_str("-79228162514264.337593543950335").unwrap();
    let _ = n.sin();
}
```

For some reason the above snippet keeps entering the `if self >= &Decimal::PI {` branch in an infinite loop overflowing the default stack size.