### PR TITLE
Auto rounding of scales 29, 30 and 31 for deserialization

### DIFF
--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -1,4 +1,4 @@
-use crate::constants::U32_MASK;
+use crate::constants::{POWERS_10, U32_MASK};
 
 /// Rescales the given decimal to new scale.
 /// e.g. with 1.23 and new scale 3 rescale the value to 1.230
@@ -207,6 +207,21 @@ pub(crate) fn div_by_u32(bits: &mut [u32], divisor: u32) -> u32 {
 
         remainder
     }
+}
+
+pub(crate) fn div_by_1x(bits: &mut [u32; 3], power: usize) -> u32 {
+    let mut remainder = 0u32;
+    let divisor = POWERS_10[power] as u64;
+    let temp = ((remainder as u64) << 32) + (bits[2] as u64);
+    remainder = (temp % divisor) as u32;
+    bits[2] = (temp / divisor) as u32;
+    let temp = ((remainder as u64) << 32) + (bits[1] as u64);
+    remainder = (temp % divisor) as u32;
+    bits[1] = (temp / divisor) as u32;
+    let temp = ((remainder as u64) << 32) + (bits[0] as u64);
+    remainder = (temp % divisor) as u32;
+    bits[0] = (temp / divisor) as u32;
+    remainder
 }
 
 #[inline]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -133,19 +133,37 @@ fn it_can_serialize_deserialize() {
 }
 
 #[test]
-#[should_panic(expected = "Scale exceeds the maximum precision allowed: 30 > 28")]
-fn it_panics_deserializing_unbounded_values() {
-    let _ = Decimal::deserialize([1u8, 0, 30, 206, 97, 81, 216, 182, 20, 30, 165, 78, 18, 155, 169, 62]);
-}
-
-#[test]
-fn it_can_deserialize_bounded_values() {
-    let tests = [[1u8, 0, 28, 206, 97, 81, 216, 182, 20, 30, 165, 78, 18, 155, 169, 62]];
-    for &bytes in &tests {
+fn it_can_deserialize_unbounded_values() {
+    // Mantissa for these: 19393111376951473493673267553
+    let tests = [
+        (
+            [1u8, 0, 28, 206, 97, 81, 216, 182, 20, 30, 165, 78, 18, 155, 169, 62],
+            // Scale 28: -1.9393111376951473493673267553
+            "-1.9393111376951473493673267553",
+        ),
+        (
+            [1u8, 0, 29, 206, 97, 81, 216, 182, 20, 30, 165, 78, 18, 155, 169, 62],
+            // Scale 29: -0.19393111376951473493673267553
+            "-0.1939311137695147349367326755",
+        ),
+        (
+            [1u8, 0, 30, 206, 97, 81, 216, 182, 20, 30, 165, 78, 18, 155, 169, 62],
+            // Scale 30: -0.019393111376951473493673267553
+            "-0.0193931113769514734936732676",
+        ),
+        (
+            [1u8, 0, 31, 206, 97, 81, 216, 182, 20, 30, 165, 78, 18, 155, 169, 62],
+            // Scale 31: -0.0019393111376951473493673267553
+            "-0.0019393111376951473493673268",
+        ),
+    ];
+    for &(bytes, expected) in &tests {
         let dec = Decimal::deserialize(bytes);
         let string = format!("{:.9999}", dec);
         let dec2 = Decimal::from_str(&string).unwrap();
         assert_eq!(dec, dec2);
+        assert_eq!(dec.to_string(), expected, "dec.to_string()");
+        assert_eq!(dec2.to_string(), expected, "dec2.to_string()");
     }
 }
 


### PR DESCRIPTION
Removes introduced panic by leveraging an automatic round. Still a breaking change due to `const` being removed (i.e. `mut` prevents `const` right now) however is closer than before by avoiding a runtime panic.

Fixes #435 