### PR TITLE
Fixes significant figure calcs for small numbers

### DIFF
--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -2438,6 +2438,9 @@ fn it_can_round_significant_figures_with_strategy() {
         ("123.01", 3u32, RoundingStrategy::AwayFromZero, Some("124")),
         ("1.2301", 3u32, RoundingStrategy::AwayFromZero, Some("1.24")),
         ("0.12301", 3u32, RoundingStrategy::AwayFromZero, Some("0.124")),
+        ("0.012301", 3u32, RoundingStrategy::AwayFromZero, Some("0.0124")),
+        ("0.0000012301", 3u32, RoundingStrategy::AwayFromZero, Some("0.00000124")),
+        ("1.012301", 3u32, RoundingStrategy::AwayFromZero, Some("1.02")),
     ];
     for &(input, sf, strategy, expected) in tests {
         let input = Decimal::from_str(input).unwrap();


### PR DESCRIPTION
Fixes #437 

The previous code incorrectly assumed that numbers right of the decimal point when `0 < x < 1` were significant. For example, `0.0012301` would calculate as `7` significant figures. According to various literature ([example](http://www.ruf.rice.edu/~kekule/SignificantFigureRules1.pdf)), because the first two zeros are not involved in measurement decisions they can be simplified as to how it is represented. In the case above we could simplify to `1.2301 x 10^-3` consequently requiring only `5` significant figures to represent. 
Because Rust Decimal implicitly stores numbers like this beneath the surface (e.g. above would be stored as `12301 x 10^-7`) we can easily extract the significant figures by relying on the mantissa only.

The logic for SF rounding currently leverages the difference between current sf and requested sf to perform calculation. Using the same example, if we were trying to round to 3 significant figures then previously we would try to adjust by `7 - 3 = 4` decimal points which would result in `0.001` (`1 x 10^-3`) i.e. it assumes that the `0`s are significant.

The new code aligns with the literature and instead ignores the leading `0`s. The dp adjustment used is `5 - 3 = 2` which consequently gives the result `0.00123` (`123 x 10^-5`) i.e. the leading `0`s are not significant.