### PR TITLE
Feature: Retain excess precision during float conversions

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1418,9 +1418,9 @@ impl Decimal {
     /// assert_eq!("0.1", Decimal::from_f32(0.1_f32).unwrap().to_string());
     ///
     /// // Sometimes, we may want to represent the approximation exactly.
-    /// assert_eq!("0.100000001490116119384765625", Decimal::from_f32_retain_excess_bits(0.1_f32).unwrap().to_string());
+    /// assert_eq!("0.100000001490116119384765625", Decimal::from_f32_retain(0.1_f32).unwrap().to_string());
     /// ```
-    pub fn from_f32_retain_excess_bits(n: f32) -> Option<Self> {
+    pub fn from_f32_retain(n: f32) -> Option<Self> {
         from_f32(n, false)
     }
 
@@ -1439,9 +1439,9 @@ impl Decimal {
     /// assert_eq!("0.1", Decimal::from_f64(0.1_f64).unwrap().to_string());
     ///
     /// // Sometimes, we may want to represent the approximation exactly.
-    /// assert_eq!("0.1000000000000000055511151231", Decimal::from_f64_retain_excess_bits(0.1_f64).unwrap().to_string());
+    /// assert_eq!("0.1000000000000000055511151231", Decimal::from_f64_retain(0.1_f64).unwrap().to_string());
     /// ```
-    pub fn from_f64_retain_excess_bits(n: f64) -> Option<Self> {
+    pub fn from_f64_retain(n: f64) -> Option<Self> {
         from_f64(n, false)
     }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -2769,8 +2769,8 @@ fn it_converts_from_f32_retaining_bits() {
     for &(input, expected) in &tests {
         assert_eq!(
             expected,
-            Decimal::from_f32_retain_excess_bits(input).unwrap().to_string(),
-            "from_f32_retain_excess_bits({})",
+            Decimal::from_f32_retain(input).unwrap().to_string(),
+            "from_f32_retain({})",
             input
         );
     }
@@ -2838,8 +2838,8 @@ fn it_converts_from_f64_retaining_bits() {
     for &(input, expected) in &tests {
         assert_eq!(
             expected,
-            Decimal::from_f64_retain_excess_bits(input).unwrap().to_string(),
-            "from_f64_retain_excess_bits({})",
+            Decimal::from_f64_retain(input).unwrap().to_string(),
+            "from_f64_retain({})",
             input
         );
     }


### PR DESCRIPTION
Fixes #438 

Additional functions `from_f32_retain` and `from_f64_retain` created to retain additional float bits while parsing `f32`/`f64` respectively.