### PR TITLE
Add num_traits `Signed` to prelude

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub mod prelude {
     pub use crate::maths::MathematicalOps;
     pub use crate::{Decimal, RoundingStrategy};
     pub use core::str::FromStr;
-    pub use num_traits::{FromPrimitive, One, ToPrimitive, Zero};
+    pub use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
 }
 
 #[cfg(feature = "diesel")]


### PR DESCRIPTION
First of all, thanks for the awesome crate!

Currently the `.signum()` method cannot be used when importing `prelude` without adding `num-traits` as a specific dependency in a downstream crate and importing manually. 

Other used `num_traits` traits are currently reexported under the prelude module so I think this tiny change to align makes sense? 

Example error message when trying to use currently:  

```
error[E0599]: no method named `signum` found for struct `rust_decimal::Decimal` in the current scope
   --> mycode/mod.rs:465:88
    |
465 |             myvalue.signum();
    |                     ^^^^^^ method not found in `rust_decimal::Decimal`
    |
   ::: /home/james/.cargo/registry/src/github.com-1ecc6299db9ec823/num-traits-0.2.14/src/sign.rs:35:8
    |
35  |     fn signum(&self) -> Self;
    |        ------ the method is available for `rust_decimal::Decimal` here
    |
    = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
    |
1   | use num_traits::sign::Signed;```