### PR TITLE
Exercise `Decimal::deserialize`

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -103,7 +103,7 @@ run by using `makers fuzz`.
 In order to ensure that Rust Decimal runs quickly, a number of benchmarks have been created and can be executed using
 `makers bench`. 
 
-When adding new benchmarking configurations please ensure that you add a corresponding `Makefile.toml` task to capture the
+When adding new benchmarking configurations, please ensure that you add a corresponding `Makefile.toml` task to capture the
 updated configuration.
 
 ## Code Coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ test = false
 arbitrary = { features = ["derive"], version = "1.0" }
 libfuzzer-sys = "0.4"
 rust_decimal = { features = ["maths", "rust-fuzz"], path = ".." }
+serde_json = { default-features = false, features = ["alloc"], version = "1.0" }
 
 [package]
 authors = ["Automatically generated"]

--- a/fuzz/fuzz_targets/constructors.rs
+++ b/fuzz/fuzz_targets/constructors.rs
@@ -4,7 +4,7 @@ use rust_decimal::Decimal;
 
 #[derive(Debug, arbitrary::Arbitrary)]
 struct Data<'a> {
-    from_scientific_value: &'a str,
+    generic_str: &'a str,
 
     try_from_i128_with_scale_num: i128,
     try_from_i128_with_scale_scale: u32,
@@ -14,7 +14,9 @@ struct Data<'a> {
 }
 
 libfuzzer_sys::fuzz_target!(|data: Data<'_>| {
-    let _ = Decimal::from_scientific(data.from_scientific_value);
+    let _ = serde_json::from_str::<Decimal>(data.generic_str);
+
+    let _ = Decimal::from_scientific(data.generic_str);
 
     let _ = Decimal::try_from_i128_with_scale(data.try_from_i128_with_scale_num, data.try_from_i128_with_scale_scale);
 


### PR DESCRIPTION
I guess this is the last fallible `Decimal` constructor