### PR TITLE
Attempt to fix `from_str` overflow rounding

### DIFF
--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -92,6 +92,24 @@ pub(crate) fn add_by_internal(value: &mut [u32], by: &[u32]) -> u32 {
     carry as u32
 }
 
+pub(crate) fn add_by_internal_flattened(value: &mut [u32; 3], by: u32) -> u32 {    let mut carry: u64;
+    let mut sum: u64;
+    sum = u64::from(value[0]) + u64::from(by);
+    value[0] = (sum & U32_MASK) as u32;
+    carry = sum >> 32;
+    if carry > 0 {
+        sum = u64::from(value[1]) + carry;
+        value[1] = (sum & U32_MASK) as u32;
+        carry = sum >> 32;
+        if carry > 0 {
+            sum = u64::from(value[2]) + carry;
+            value[2] = (sum & U32_MASK) as u32;
+            carry = sum >> 32;
+        }
+    }
+    carry as u32
+}
+
 #[inline]
 pub(crate) fn add_one_internal(value: &mut [u32]) -> u32 {
     let mut carry: u64 = 1; // Start with one, since adding one

--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -54,6 +54,7 @@ pub(crate) fn rescale_internal(value: &mut [u32; 3], value_scale: &mut u32, new_
     }
 }
 
+#[cfg(feature = "legacy-ops")]
 pub(crate) fn add_by_internal(value: &mut [u32], by: &[u32]) -> u32 {
     let mut carry: u64 = 0;
     let vl = value.len();
@@ -92,7 +93,8 @@ pub(crate) fn add_by_internal(value: &mut [u32], by: &[u32]) -> u32 {
     carry as u32
 }
 
-pub(crate) fn add_by_internal_flattened(value: &mut [u32; 3], by: u32) -> u32 {    let mut carry: u64;
+pub(crate) fn add_by_internal_flattened(value: &mut [u32; 3], by: u32) -> u32 {
+    let mut carry: u64;
     let mut sum: u64;
     sum = u64::from(value[0]) + u64::from(by);
     value[0] = (sum & U32_MASK) as u32;

--- a/src/str.rs
+++ b/src/str.rs
@@ -183,7 +183,7 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
     }
 
     // If we exited before the end of the string then do some rounding if necessary
-    if maybe_round && offset < bytes.len() {
+    if maybe_round && offset < bytes.len() && digits_before_dot >= 0 {
         let next_byte = bytes[offset];
         let digit = match next_byte {
             b'0'..=b'9' => u32::from(next_byte - b'0'),
@@ -541,7 +541,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
 
 #[cfg(test)]
 mod test {
-    use super::{parse_str_radix_10, Error};
+    use super::Error;
     use crate::Decimal;
     use arrayvec::ArrayString;
     use core::{fmt::Write, str::FromStr};
@@ -558,8 +558,7 @@ mod test {
     fn from_str_overflow_1() {
         assert_eq!(
             Decimal::from_str("99999_99999_99999_99999_99999_99999.99999"),
-            // it returns   Ok(100000_00000_00000_00000_00000_000) now
-            Err(Error::from("Invalid decimal: overflow from too many digits"))
+            Err(Error::from("Invalid decimal: overflow from scale mismatch"))
         );
     }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -555,6 +555,83 @@ mod test {
     }
 
     #[test]
+    fn from_str_rounding_0() {
+        assert_eq!(Decimal::from_str("1.234").unwrap(), Decimal::new(1234, 3));
+    }
+
+    #[test]
+    fn from_str_rounding_1() {
+        assert_eq!(
+            Decimal::from_str("11111_11111_11111.11111_11111_11111").unwrap(),
+            Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_111, 14)
+        );
+    }
+
+    #[test]
+    fn from_str_rounding_2() {
+        assert_eq!(
+            Decimal::from_str("11111_11111_11111.11111_11111_11115").unwrap(),
+            Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_112, 14)
+        );
+    }
+
+    #[test]
+    fn from_str_rounding_3() {
+        assert_eq!(
+            Decimal::from_str("11111_11111_11111.11111_11111_11195").unwrap(),
+            Decimal::from_i128_with_scale(1_111_111_111_111_111_111_111_111_112, 13)
+        );
+    }
+
+    #[test]
+    fn from_str_rounding_4() {
+        assert_eq!(
+            Decimal::from_str("99999_99999_99999.99999_99999_99995").unwrap(),
+            Decimal::from_i128_with_scale(1_000_000_000_000_000_000_000_000_000, 12)
+        );
+    }
+
+    #[test]
+    fn from_str_leading_0s_1() {
+        assert_eq!(
+            Decimal::from_str("00001.1").unwrap(),
+            Decimal::from_i128_with_scale(11, 1)
+        );
+    }
+
+    #[test]
+    fn from_str_leading_0s_2() {
+        assert_eq!(
+            Decimal::from_str("00000_00000_00000_00000_00001.00001").unwrap(),
+            Decimal::from_i128_with_scale(100001, 5)
+        );
+    }
+
+    #[test]
+    fn from_str_leading_0s_3() {
+        assert_eq!(
+            Decimal::from_str("0.00000_00000_00000_00000_00000_00100").unwrap(),
+            Decimal::from_i128_with_scale(1, 28)
+        );
+    }
+
+    #[test]
+    fn from_str_trailing_0s_1() {
+        assert_eq!(
+            Decimal::from_str("0.00001_00000_00000").unwrap(),
+            Decimal::from_i128_with_scale(1, 5)
+        );
+    }
+
+    #[test]
+    fn from_str_trailing_0s_2() {
+        assert_eq!(
+            Decimal::from_str("0.00001_00000_00000_00000_00000_00000").unwrap(),
+            Decimal::from_i128_with_scale(1, 5)
+        );
+    }
+
+    #[test]
     fn from_str_overflow_1() {
         assert_eq!(
             Decimal::from_str("99999_99999_99999_99999_99999_99999.99999"),
@@ -583,6 +660,43 @@ mod test {
         assert_eq!(
             Decimal::from_str("99999_99999_99999_99999_99999_999.99").unwrap(),
             Decimal::from_i128_with_scale(10_000_000_000_000_000_000_000_000_000, 0)
+        );
+    }
+
+    #[test]
+    fn from_str_edge_cases_1() {
+        assert_eq!(Decimal::from_str(""), Err(Error::from("Invalid decimal: empty")));
+    }
+
+    #[test]
+    fn from_str_edge_cases_2() {
+        assert_eq!(
+            Decimal::from_str("0.1."),
+            Err(Error::from("Invalid decimal: two decimal points"))
+        );
+    }
+
+    #[test]
+    fn from_str_edge_cases_3() {
+        assert_eq!(
+            Decimal::from_str("_"),
+            Err(Error::from("Invalid decimal: must start lead with a number"))
+        );
+    }
+
+    #[test]
+    fn from_str_edge_cases_4() {
+        assert_eq!(
+            Decimal::from_str("1?2"),
+            Err(Error::from("Invalid decimal: unknown character"))
+        );
+    }
+
+    #[test]
+    fn from_str_edge_cases_5() {
+        assert_eq!(
+            Decimal::from_str("."),
+            Err(Error::from("Invalid decimal: no digits found"))
         );
     }
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{MAX_PRECISION, MAX_STR_BUFFER_SIZE},
     error::Error,
-    ops::array::{add_by_internal, add_one_internal, div_by_u32, is_all_zero, mul_by_10, mul_by_u32},
+    ops::array::{add_by_internal_flattened, add_one_internal, div_by_u32, is_all_zero, mul_by_10, mul_by_u32},
     Decimal,
 };
 
@@ -267,7 +267,7 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
             data[0] = tmp[0];
             data[1] = tmp[1];
             data[2] = tmp[2];
-            let carry = add_by_internal(&mut data, &[*digit]);
+            let carry = add_by_internal_flattened(&mut data, *digit);
             if carry > 0 {
                 // Highly unlikely scenario which is more indicative of a bug
                 return Err(Error::from("Invalid decimal: overflow from carry"));
@@ -528,7 +528,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             data[0] = tmp[0];
             data[1] = tmp[1];
             data[2] = tmp[2];
-            let carry = add_by_internal(&mut data, &[*digit]);
+            let carry = add_by_internal_flattened(&mut data, *digit);
             if carry > 0 {
                 // Highly unlikely scenario which is more indicative of a bug
                 return Err(Error::from("Invalid decimal: overflow from carry"));


### PR DESCRIPTION
resolves #453

The culprit is the rounding behaviour prevented it from overflowing, and ended up returning an `Ok` in the end. The fix is: we should not attempt to round a number before the decimal point.

Having read through the code, I think there are opportunities to make `parse_str_radix_10` faster & simpler, e.g. removing the coeff `ArrayVec` and doing it in one pass; using 128 bit integer arithmetic etc.

I wonder what is your view on this?