### PR TITLE
Optimize `parse_str_radix_10`

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -65,3 +65,6 @@ pub const MAX_I32_SCALE: i32 = 9;
 pub const MAX_I64_SCALE: u32 = 19;
 #[cfg(not(feature = "legacy-ops"))]
 pub const U32_MAX: u64 = u32::MAX as u64;
+
+// Determines potential overflow for 128 bit operations
+pub const OVERFLOW_96: u128 = 1u128 << 96;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -67,4 +67,6 @@ pub const MAX_I64_SCALE: u32 = 19;
 pub const U32_MAX: u64 = u32::MAX as u64;
 
 // Determines potential overflow for 128 bit operations
-pub const OVERFLOW_96: u128 = 1u128 << 96;
+pub const OVERFLOW_U96: u128 = 1u128 << 96;
+pub const WILL_OVERFLOW_U64: u64 = u64::MAX / 10 - u8::MAX as u64;
+pub const BYTES_TO_OVERFLOW_U64: usize = 18; // We can probably get away with less

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -83,7 +83,7 @@ const NEGATIVE_ONE: Decimal = Decimal {
 
 /// `UnpackedDecimal` contains unpacked representation of `Decimal` where each component
 /// of decimal-format stored in it's own field
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UnpackedDecimal {
     pub negative: bool,
     pub scale: u32,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::constants::MAX_PRECISION_U32;
+use crate::{constants::MAX_PRECISION_U32, Decimal};
 use alloc::string::String;
 use core::fmt;
 
@@ -19,6 +19,11 @@ where
     fn from(from: S) -> Self {
         Self::ErrorString(from.into())
     }
+}
+
+#[cold]
+pub(crate) fn tail_error(from: &'static str) -> Result<Decimal, Error> {
+    Err(from.into())
 }
 
 #[cfg(feature = "std")]

--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -54,6 +54,7 @@ pub(crate) fn rescale_internal(value: &mut [u32; 3], value_scale: &mut u32, new_
     }
 }
 
+#[cfg(feature = "legacy-ops")]
 pub(crate) fn add_by_internal(value: &mut [u32], by: &[u32]) -> u32 {
     let mut carry: u64 = 0;
     let vl = value.len();
@@ -88,6 +89,25 @@ pub(crate) fn add_by_internal(value: &mut [u32], by: &[u32]) -> u32 {
         }
     } else {
         panic!("Internal error: add using incompatible length arrays. {} <- {}", vl, bl);
+    }
+    carry as u32
+}
+
+pub(crate) fn add_by_internal_flattened(value: &mut [u32; 3], by: u32) -> u32 {
+    let mut carry: u64;
+    let mut sum: u64;
+    sum = u64::from(value[0]) + u64::from(by);
+    value[0] = (sum & U32_MASK) as u32;
+    carry = sum >> 32;
+    if carry > 0 {
+        sum = u64::from(value[1]) + carry;
+        value[1] = (sum & U32_MASK) as u32;
+        carry = sum >> 32;
+        if carry > 0 {
+            sum = u64::from(value[2]) + carry;
+            value[2] = (sum & U32_MASK) as u32;
+            carry = sum >> 32;
+        }
     }
     carry as u32
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -632,86 +632,105 @@ mod test {
 
     #[test]
     fn from_str_rounding_0() {
-        assert_eq!(parse_str_radix_10("1.234").unwrap(), Decimal::new(1234, 3));
+        assert_eq!(
+            parse_str_radix_10("1.234").unwrap().unpack(),
+            Decimal::new(1234, 3).unpack()
+        );
     }
 
     #[test]
     fn from_str_rounding_1() {
         assert_eq!(
-            parse_str_radix_10("11111_11111_11111.11111_11111_11111").unwrap(),
-            Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_111, 14)
+            parse_str_radix_10("11111_11111_11111.11111_11111_11111")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_111, 14).unpack()
         );
     }
 
     #[test]
     fn from_str_rounding_2() {
         assert_eq!(
-            parse_str_radix_10("11111_11111_11111.11111_11111_11115").unwrap(),
-            Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_112, 14)
+            parse_str_radix_10("11111_11111_11111.11111_11111_11115")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(11_111_111_111_111_111_111_111_111_112, 14).unpack()
         );
     }
 
     #[test]
     fn from_str_rounding_3() {
         assert_eq!(
-            parse_str_radix_10("11111_11111_11111.11111_11111_11195").unwrap(),
-            Decimal::from_i128_with_scale(1_111_111_111_111_111_111_111_111_112, 13)
+            parse_str_radix_10("11111_11111_11111.11111_11111_11195")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(1_111_111_111_111_111_111_111_111_1120, 14).unpack() // was Decimal::from_i128_with_scale(1_111_111_111_111_111_111_111_111_112, 13)
         );
     }
 
     #[test]
     fn from_str_rounding_4() {
         assert_eq!(
-            parse_str_radix_10("99999_99999_99999.99999_99999_99995").unwrap(),
-            Decimal::from_i128_with_scale(1_000_000_000_000_000_000_000_000_000, 12)
+            parse_str_radix_10("99999_99999_99999.99999_99999_99995")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(10_000_000_000_000_000_000_000_000_000, 13).unpack() // was Decimal::from_i128_with_scale(1_000_000_000_000_000_000_000_000_000, 12)
         );
     }
 
     #[test]
     fn from_str_many_pointless_chars() {
         assert_eq!(
-            parse_str_radix_10("00________________________________________________________________001.1").unwrap(),
-            Decimal::from_i128_with_scale(11, 1)
+            parse_str_radix_10("00________________________________________________________________001.1")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(11, 1).unpack()
         );
     }
 
     #[test]
     fn from_str_leading_0s_1() {
         assert_eq!(
-            parse_str_radix_10("00001.1").unwrap(),
-            Decimal::from_i128_with_scale(11, 1)
+            parse_str_radix_10("00001.1").unwrap().unpack(),
+            Decimal::from_i128_with_scale(11, 1).unpack()
         );
     }
 
     #[test]
     fn from_str_leading_0s_2() {
         assert_eq!(
-            parse_str_radix_10("00000_00000_00000_00000_00001.00001").unwrap(),
-            Decimal::from_i128_with_scale(100001, 5)
+            parse_str_radix_10("00000_00000_00000_00000_00001.00001")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(100001, 5).unpack()
         );
     }
 
     #[test]
     fn from_str_leading_0s_3() {
         assert_eq!(
-            parse_str_radix_10("0.00000_00000_00000_00000_00000_00100").unwrap(),
-            Decimal::from_i128_with_scale(1, 28)
+            parse_str_radix_10("0.00000_00000_00000_00000_00000_00100")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(1, 28).unpack()
         );
     }
 
     #[test]
     fn from_str_trailing_0s_1() {
         assert_eq!(
-            parse_str_radix_10("0.00001_00000_00000").unwrap(),
-            Decimal::from_i128_with_scale(1, 5)
+            parse_str_radix_10("0.00001_00000_00000").unwrap().unpack(),
+            Decimal::from_i128_with_scale(10_000_000_000, 15).unpack()
         );
     }
 
     #[test]
     fn from_str_trailing_0s_2() {
         assert_eq!(
-            parse_str_radix_10("0.00001_00000_00000_00000_00000_00000").unwrap(),
-            Decimal::from_i128_with_scale(1, 5)
+            parse_str_radix_10("0.00001_00000_00000_00000_00000_00000")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(100_000_000_000_000_000_000_000, 28).unpack()
         );
     }
 
@@ -748,8 +767,10 @@ mod test {
         assert_eq!(
             // This does not overflow, moving the decimal point 1 more step would result in
             // 'overflow from too many digits'
-            parse_str_radix_10("99999_99999_99999_99999_99999_999.99").unwrap(),
-            Decimal::from_i128_with_scale(10_000_000_000_000_000_000_000_000_000, 0)
+            parse_str_radix_10("99999_99999_99999_99999_99999_999.99")
+                .unwrap()
+                .unpack(),
+            Decimal::from_i128_with_scale(10_000_000_000_000_000_000_000_000_000, 0).unpack()
         );
     }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -132,37 +132,101 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
         return Err(Error::from("Invalid decimal: empty"));
     }
 
-    let bytes = str.as_bytes();
+    let mut bytes = str.as_bytes();
     let mut negative = false; // assume positive
 
     // handle the sign
-    let bytes = if bytes[0] == b'-' {
-        negative = true; // leading minus means negative
-        &bytes[1..]
-    } else if bytes[0] == b'+' {
-        // leading + allowed
-        &bytes[1..]
-    } else {
-        bytes
+
+    bytes = match bytes[0] {
+        b'-' => {
+            negative = true; // leading minus means negative
+            &bytes[1..]
+        }
+        b'+' => {
+            // leading + allowed
+            &bytes[1..]
+        }
+        _ => bytes,
     };
 
     // should now be at numeric part of the significand
-    let len = bytes.len();
-    let mut offset = 0;
     let mut passed_decimal_point = false;
     let mut has_digit = false;
-    let mut data: u128 = 0;
-    let mut coeff: u32 = 0; // number of digits
-    let mut scale = 0;
-    let mut maybe_round = false;
+    let mut coeff: u8 = 0; // number of digits
+    let mut scale: u8 = 0;
 
-    while offset < len {
-        let b = bytes[offset];
+    let mut data64: u64 = 0;
+
+    while data64 < (u64::MAX / 10 - u8::MAX as u64) {
+        // no overflow can happen here!
+        if !bytes.is_empty() {
+            let b = bytes[0];
+            match b {
+                b'0'..=b'9' => {
+                    let digit = u32::from(b - b'0');
+                    has_digit = true;
+                    coeff += if coeff == 0 && digit == 0 { 0 } else { 1 }; // got one more digit
+
+                    // we have already validated that we cannot overflow
+                    data64 = data64 * 10 + digit as u64;
+                    scale += passed_decimal_point as u8;
+                }
+                b'.' => {
+                    if passed_decimal_point {
+                        return Err(Error::from("Invalid decimal: two decimal points"));
+                    }
+                    passed_decimal_point = true;
+                }
+                b'_' => {
+                    // Must start with a number...
+                    if !has_digit {
+                        return Err(Error::from("Invalid decimal: must start lead with a number"));
+                    }
+                }
+                _ => return Err(Error::from("Invalid decimal: unknown character")),
+            }
+            bytes = &bytes[1..];
+
+            debug_assert!(coeff < MAX_PRECISION as u8);
+            if scale >= 28 {
+                if !bytes.is_empty() {
+                    return maybe_round(data64 as u128, bytes[0], scale, negative, passed_decimal_point);
+                }
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    let data: u128 = data64 as u128;
+
+    if !bytes.is_empty() {
+        return handle_full_128(data, bytes, scale, coeff, passed_decimal_point, negative);
+    } else if !has_digit {
+        return Err(Error::from("Invalid decimal: no digits found"));
+    }
+
+    handle_data(data, scale, negative)
+}
+
+#[inline(never)]
+#[cold]
+fn handle_full_128(
+    mut data: u128,
+    mut bytes: &[u8],
+    mut scale: u8,
+    mut coeff: u8,
+    mut passed_decimal_point: bool,
+    negative: bool,
+) -> Result<Decimal, crate::Error> {
+    while !bytes.is_empty() {
+        debug_assert!(coeff > 0);
+        let b = bytes[0];
         match b {
             b'0'..=b'9' => {
                 let digit = u32::from(b - b'0');
-                has_digit = true;
-                coeff += if coeff == 0 && digit == 0 { 0 } else { 1 }; // got one more digit
+                coeff += 1; // got one more digit
 
                 // If the data is going to overflow then we should go into recovery mode
                 let next = data * 10;
@@ -184,12 +248,10 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
                     break;
                 } else {
                     data = next + digit as u128;
-                    if passed_decimal_point {
-                        scale += 1;
-                    }
+                    scale += passed_decimal_point as u8;
                     if overflows(data) {
                         // Highly unlikely scenario which is more indicative of a bug
-                        return Err(Error::from("Invalid decimal: overflow from carry"));
+                        return Err(Error::from("Invalid decimal: overflow when rounding"));
                     }
                 }
             }
@@ -199,56 +261,62 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
                 }
                 passed_decimal_point = true;
             }
-            b'_' => {
-                // Must start with a number...
-                if offset == 0 {
-                    return Err(Error::from("Invalid decimal: must start lead with a number"));
-                }
-            }
+            b'_' => {}
             _ => return Err(Error::from("Invalid decimal: unknown character")),
         }
-        offset += 1;
+        bytes = &bytes[1..];
 
-        if coeff > MAX_PRECISION as u32 || scale >= 28 {
-            maybe_round = true;
+        if coeff > MAX_PRECISION as u8 || scale >= 28 {
+            if !bytes.is_empty() {
+                return maybe_round(data, bytes[0], scale, negative, passed_decimal_point);
+            }
             break;
         }
     }
 
-    if !has_digit {
-        return Err(Error::from("Invalid decimal: no digits found"));
-    }
+    handle_data(data, scale, negative)
+}
 
-    // If we exited before the end of the string then do some rounding if necessary
-    if maybe_round && offset < bytes.len() {
-        let next_byte = bytes[offset];
-        let digit = match next_byte {
-            b'0'..=b'9' => u32::from(next_byte - b'0'),
-            b'_' => 0, // this is a bug?
-            b'.' => {
-                // Still an error if we have a second dp
-                if passed_decimal_point {
-                    return Err(Error::from("Invalid decimal: two decimal points"));
-                }
-                0
+#[inline(never)]
+#[cold]
+fn maybe_round(
+    mut data: u128,
+    next_byte: u8,
+    scale: u8,
+    negative: bool,
+    passed_decimal_point: bool,
+) -> Result<Decimal, crate::Error> {
+    let digit = match next_byte {
+        b'0'..=b'9' => u32::from(next_byte - b'0'),
+        b'_' => 0, // this is a bug?
+        b'.' => {
+            // Still an error if we have a second dp
+            if passed_decimal_point {
+                return Err(Error::from("Invalid decimal: two decimal points"));
             }
-            _ => return Err(Error::from("Invalid decimal: unknown character")),
-        };
+            0
+        }
+        _ => return Err(Error::from("Invalid decimal: unknown character")),
+    };
 
-        // Round at midpoint
-        if digit >= 5 {
-            data += 1;
-            if overflows(data) {
-                // Highly unlikely scenario which is more indicative of a bug
-                return Err(Error::from("Invalid decimal: overflow when rounding"));
-            }
+    // Round at midpoint
+    if digit >= 5 {
+        data += 1;
+        if overflows(data) {
+            // Highly unlikely scenario which is more indicative of a bug
+            return Err(Error::from("Invalid decimal: overflow when rounding"));
         }
     }
 
+    handle_data(data, scale, negative)
+}
+
+fn handle_data(data: u128, scale: u8, negative: bool) -> Result<Decimal, crate::Error> {
     debug_assert_eq!(data >> 96, 0);
+
     let data = [data as u32, (data >> 32) as u32, (data >> 64) as u32];
 
-    Ok(Decimal::from_parts(data[0], data[1], data[2], negative, scale))
+    Ok(Decimal::from_parts(data[0], data[1], data[2], negative, scale as u32))
 }
 
 pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate::Error> {

--- a/src/str.rs
+++ b/src/str.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{MAX_PRECISION, MAX_STR_BUFFER_SIZE},
     error::Error,
-    ops::array::{add_by_internal, add_one_internal, div_by_u32, is_all_zero, mul_by_10, mul_by_u32},
+    ops::array::{add_by_internal_flattened, add_one_internal, div_by_u32, is_all_zero, mul_by_10, mul_by_u32},
     Decimal,
 };
 
@@ -128,69 +128,110 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
     }
 
     let mut offset = 0;
-    let mut len = str.len();
+    let len = str.len();
     let bytes = str.as_bytes();
     let mut negative = false; // assume positive
 
     // handle the sign
-    if bytes[offset] == b'-' {
-        negative = true; // leading minus means negative
-        offset += 1;
-        len -= 1;
-    } else if bytes[offset] == b'+' {
-        // leading + allowed
-        offset += 1;
-        len -= 1;
+    match bytes[offset] {
+        b'-' => {
+            negative = true; // leading minus means negative
+            offset += 1;
+        }
+        b'+' => {
+            // leading + allowed
+            offset += 1;
+        }
+        _ => {}
     }
 
     // should now be at numeric part of the significand
-    let mut digits_before_dot: i32 = -1; // digits before '.', -1 if no '.'
-    let mut coeff = ArrayVec::<_, MAX_STR_BUFFER_SIZE>::new(); // integer significand array
-
+    let mut passed_decimal_point = false;
+    let mut has_digit = false;
+    let mut coeff: u32 = 0; // number of digits
+    let mut scale = 0;
     let mut maybe_round = false;
-    while len > 0 {
+
+    let mut data = [0u32, 0u32, 0u32];
+    let mut tmp = [0u32, 0u32, 0u32];
+    while offset < len {
         let b = bytes[offset];
         match b {
             b'0'..=b'9' => {
-                coeff.push(u32::from(b - b'0'));
-                offset += 1;
-                len -= 1;
+                let digit = u32::from(b - b'0');
+                has_digit = true;
+                coeff += if coeff == 0 && digit == 0 { 0 } else { 1 }; // got one more digit
 
-                // If the coefficient is longer than the max, exit early
-                if coeff.len() as u32 > 28 {
-                    maybe_round = true;
+                // If the data is going to overflow then we should go into recovery mode
+                tmp[0] = data[0];
+                tmp[1] = data[1];
+                tmp[2] = data[2];
+                let overflow = mul_by_10(&mut tmp);
+                if overflow > 0 {
+                    // This means that we have more data to process, that we're not sure what to do with.
+                    // This may or may not be an issue - depending on whether we're past a decimal point
+                    // or not.
+                    if !passed_decimal_point {
+                        return Err(Error::from("Invalid decimal: overflow from too many digits"));
+                    }
+
+                    if digit >= 5 {
+                        let carry = add_one_internal(&mut data);
+                        if carry > 0 {
+                            // Highly unlikely scenario which is more indicative of a bug
+                            return Err(Error::from("Invalid decimal: overflow when rounding"));
+                        }
+                    }
                     break;
+                } else {
+                    data[0] = tmp[0];
+                    data[1] = tmp[1];
+                    data[2] = tmp[2];
+                    let carry = add_by_internal_flattened(&mut data, digit);
+                    if passed_decimal_point {
+                        scale += 1;
+                    }
+                    if carry > 0 {
+                        // Highly unlikely scenario which is more indicative of a bug
+                        return Err(Error::from("Invalid decimal: overflow from carry"));
+                    }
                 }
             }
             b'.' => {
-                if digits_before_dot >= 0 {
+                if passed_decimal_point {
                     return Err(Error::from("Invalid decimal: two decimal points"));
                 }
-                digits_before_dot = coeff.len() as i32;
-                offset += 1;
-                len -= 1;
+                passed_decimal_point = true;
             }
             b'_' => {
                 // Must start with a number...
-                if coeff.is_empty() {
+                if offset == 0 {
                     return Err(Error::from("Invalid decimal: must start lead with a number"));
                 }
-                offset += 1;
-                len -= 1;
             }
             _ => return Err(Error::from("Invalid decimal: unknown character")),
         }
+        offset += 1;
+
+        if coeff > MAX_PRECISION as u32 || scale >= 28 {
+            maybe_round = true;
+            break;
+        }
+    }
+
+    if !has_digit {
+        return Err(Error::from("Invalid decimal: no digits found"));
     }
 
     // If we exited before the end of the string then do some rounding if necessary
-    if maybe_round && offset < bytes.len() && digits_before_dot >= 0 {
+    if maybe_round && offset < bytes.len() {
         let next_byte = bytes[offset];
         let digit = match next_byte {
             b'0'..=b'9' => u32::from(next_byte - b'0'),
-            b'_' => 0,
+            b'_' => 0, // this is a bug?
             b'.' => {
                 // Still an error if we have a second dp
-                if digits_before_dot >= 0 {
+                if passed_decimal_point {
                     return Err(Error::from("Invalid decimal: two decimal points"));
                 }
                 0
@@ -200,77 +241,10 @@ pub(crate) fn parse_str_radix_10(str: &str) -> Result<Decimal, crate::Error> {
 
         // Round at midpoint
         if digit >= 5 {
-            let mut index = coeff.len() - 1;
-            loop {
-                let new_digit = coeff[index] + 1;
-                if new_digit <= 9 {
-                    coeff[index] = new_digit;
-                    break;
-                } else {
-                    coeff[index] = 0;
-                    if index == 0 {
-                        coeff.insert(0, 1u32);
-                        digits_before_dot += 1;
-                        coeff.pop();
-                        break;
-                    }
-                }
-                index -= 1;
-            }
-        }
-    }
-
-    // here when no characters left
-    if coeff.is_empty() {
-        return Err(Error::from("Invalid decimal: no digits found"));
-    }
-
-    let mut scale = if digits_before_dot >= 0 {
-        // we had a decimal place so set the scale
-        (coeff.len() as u32) - (digits_before_dot as u32)
-    } else {
-        0
-    };
-
-    let mut data = [0u32, 0u32, 0u32];
-    let mut tmp = [0u32, 0u32, 0u32];
-    let len = coeff.len();
-    for (i, digit) in coeff.iter().enumerate() {
-        // If the data is going to overflow then we should go into recovery mode
-        tmp[0] = data[0];
-        tmp[1] = data[1];
-        tmp[2] = data[2];
-        let overflow = mul_by_10(&mut tmp);
-        if overflow > 0 {
-            // This means that we have more data to process, that we're not sure what to do with.
-            // This may or may not be an issue - depending on whether we're past a decimal point
-            // or not.
-            if (i as i32) < digits_before_dot && i + 1 < len {
-                return Err(Error::from("Invalid decimal: overflow from too many digits"));
-            }
-
-            if *digit >= 5 {
-                let carry = add_one_internal(&mut data);
-                if carry > 0 {
-                    // Highly unlikely scenario which is more indicative of a bug
-                    return Err(Error::from("Invalid decimal: overflow when rounding"));
-                }
-            }
-            // We're also one less digit so reduce the scale
-            let diff = (len - i) as u32;
-            if diff > scale {
-                return Err(Error::from("Invalid decimal: overflow from scale mismatch"));
-            }
-            scale -= diff;
-            break;
-        } else {
-            data[0] = tmp[0];
-            data[1] = tmp[1];
-            data[2] = tmp[2];
-            let carry = add_by_internal(&mut data, &[*digit]);
+            let carry = add_one_internal(&mut data);
             if carry > 0 {
                 // Highly unlikely scenario which is more indicative of a bug
-                return Err(Error::from("Invalid decimal: overflow from carry"));
+                return Err(Error::from("Invalid decimal: overflow when rounding"));
             }
         }
     }
@@ -528,7 +502,7 @@ pub(crate) fn parse_str_radix_n(str: &str, radix: u32) -> Result<Decimal, crate:
             data[0] = tmp[0];
             data[1] = tmp[1];
             data[2] = tmp[2];
-            let carry = add_by_internal(&mut data, &[*digit]);
+            let carry = add_by_internal_flattened(&mut data, *digit);
             if carry > 0 {
                 // Highly unlikely scenario which is more indicative of a bug
                 return Err(Error::from("Invalid decimal: overflow from carry"));
@@ -635,7 +609,7 @@ mod test {
     fn from_str_overflow_1() {
         assert_eq!(
             Decimal::from_str("99999_99999_99999_99999_99999_99999.99999"),
-            Err(Error::from("Invalid decimal: overflow from scale mismatch"))
+            Err(Error::from("Invalid decimal: overflow from too many digits"))
         );
     }
 
@@ -643,7 +617,7 @@ mod test {
     fn from_str_overflow_2() {
         assert_eq!(
             Decimal::from_str("99999_99999_99999_99999_99999_11111.11111"),
-            Err(Error::from("Invalid decimal: overflow from scale mismatch"))
+            Err(Error::from("Invalid decimal: overflow from too many digits"))
         );
     }
 
@@ -651,7 +625,7 @@ mod test {
     fn from_str_overflow_3() {
         assert_eq!(
             Decimal::from_str("99999_99999_99999_99999_99999_99994"),
-            Err(Error::from("Invalid decimal: overflow from scale mismatch"))
+            Err(Error::from("Invalid decimal: overflow from too many digits"))
         );
     }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -188,14 +188,14 @@ fn byte_dispatch_u64<const POINT: bool, const NEG: bool, const HAS: bool, const 
     b: u8,
 ) -> Result<Decimal, crate::Error> {
     match b {
-        b'0'..=b'9' => handle_digit_64::<POINT, NEG, HAS, BIG>(bytes, data64, scale, b - b'0'),
+        b'0'..=b'9' => handle_digit_64::<POINT, NEG, BIG>(bytes, data64, scale, b - b'0'),
         b'.' if !POINT => handle_point::<NEG, HAS, BIG>(bytes, data64, scale),
         b => non_digit_dispatch_u64::<POINT, NEG, HAS, BIG, FIRST>(bytes, data64, scale, b),
     }
 }
 
 #[inline(never)]
-fn handle_digit_64<const POINT: bool, const NEG: bool, const HAS: bool, const BIG: bool>(
+fn handle_digit_64<const POINT: bool, const NEG: bool, const BIG: bool>(
     bytes: &[u8],
     data64: u64,
     scale: u8,
@@ -209,7 +209,7 @@ fn handle_digit_64<const POINT: bool, const NEG: bool, const HAS: bool, const BI
         let next = *next;
         if POINT && BIG && scale >= 28 {
             maybe_round(data64 as u128, next, scale, POINT, NEG)
-        } else if HAS && BIG && overflow_64(data64) {
+        } else if BIG && overflow_64(data64) {
             handle_full_128::<POINT, NEG>(data64 as u128, bytes, scale, next)
         } else {
             byte_dispatch_u64::<POINT, NEG, true, BIG, false>(bytes, data64, scale, next)


### PR DESCRIPTION
Replacing #454, this PR resolves #453 and:

1. Added some tests
2. Fixed two edge cases
3. Simplified the logic of `parse_str_radix_10`
4. Optimized the performance with 64/128 bit integers
5. Speed up further with tail call optimization

Running `cargo bench --bench lib_benches -- decimal_from_str`

On M1 Pro, the numbers are:
```
master:
test decimal_from_str        ... bench:         566 ns/iter (+/- 21)

7f18e0d:
test decimal_from_str        ... bench:         88  ns/iter (+/- 21)
```

On Ryzen 3990x, the numbers are:
```
master:
test decimal_from_str        ... bench:         557 ns/iter (+/- 13)

432f9d6:
decimal_from_str             ... bench:         129 ns/iter (+/- 2)
```

I know this is a lot of code changes. No rush at all and feel free to ask us questions if pieces of the code seems unclear.

Have a happy new year too!