### PR TITLE
RoundingStrategy::MidpointTowardZero doc fix

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -125,7 +125,7 @@ pub enum RoundingStrategy {
     /// is away from zero. e.g. 6.4 -> 6, 6.5 -> 7, -6.5 -> -7
     MidpointAwayFromZero,
     /// When a number is halfway between two others, it is rounded toward the nearest number that
-    /// is toward zero. e.g. 6.4 -> 6, 6.5 -> 7, -6.5 -> -6
+    /// is toward zero. e.g. 6.4 -> 6, 6.5 -> 6, -6.5 -> -6
     MidpointTowardZero,
     /// The number is always rounded toward zero. e.g. -6.8 -> -6, 6.8 -> 6
     ToZero,


### PR DESCRIPTION
Fixes a misc typo in the examples documented for RoundingStrategy::MidpointTowardZero