### PR TITLE
Version 1.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ license = "MIT"
 name = "rust_decimal"
 readme = "./README.md"
 repository = "https://github.com/paupino/rust-decimal"
-version = "1.20.0"
+version = "1.21.0"
+build = "build.rs"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -39,10 +40,10 @@ bytes = "1.0"
 criterion = { default-features = false, version = "0.3" }
 csv = "1"
 futures = "0.3"
-serde_derive = "1.0"
+rust_decimal_macros = { path = "macros" } # This should be ok since it's just for tests
+serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"
 tokio = { features = ["rt-multi-thread", "test-util", "macros"], version = "1.0" }
-serde = { default-features = false, features = ["derive"], version = "1.0" }
 
 [features]
 c-repr = [] # Force Decimal to be repr(C)

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ To get started, add `rust_decimal` and optionally `rust_decimal_macros` to your 
 
 ```toml
 [dependencies]
-rust_decimal = "1.20"
-rust_decimal_macros = "1.20"
+rust_decimal = "1.21"
+rust_decimal_macros = "1.21"
 ```
 
 ## Usage
 
-Decimal numbers can be created in a few distinct ways. The easiest and most optimal method of creating a Decimal is to use the procedural macro within the `rust_decimal_macros` crate:
+Decimal numbers can be created in a few distinct ways. The easiest and most efficient method of creating a Decimal is to use the procedural macro within the `rust_decimal_macros` crate:
 
 ```rust
 // Procedural macros need importing directly
@@ -104,7 +104,7 @@ Forces `Decimal` to use `[repr(C)]`. The corresponding target layout is 128 bit 
 
 ### `db-postgres`
 
-This feature enables a PostgreSQL communication module. It allows for reading and writing the `Decimal`
+Enables a PostgreSQL communication module. It allows for reading and writing the `Decimal`
 type by transparently serializing/deserializing into the `NUMERIC` data type within PostgreSQL.
 
 ### `db-tokio-postgres`
@@ -120,6 +120,8 @@ Enable `diesel` PostgreSQL support.
 Enable `diesel` MySQL support.
 
 ### `legacy-ops`
+
+**Warning:** This is deprecated and will be removed from a future versions.
 
 As of `1.10` the algorithms used to perform basic operations have changed which has benefits of significant speed improvements.
 To maintain backwards compatibility this can be opted out of by enabling the `legacy-ops` feature.
@@ -183,7 +185,7 @@ This is recommended when parsing "float" looking data as it will prevent data lo
 
 ### `serde-with-float`
 
-Enable this to access the module for serialising `Decimal` types to a float. This can be use in `struct` definitions like so:
+Enable this to access the module for serializing `Decimal` types to a float. This can be use in `struct` definitions like so:
 
 ```rust
 #[derive(Serialize, Deserialize)]
@@ -195,7 +197,7 @@ pub struct FloatExample {
 
 ### `serde-with-str`
 
-Enable this to access the module for serialising `Decimal` types to a `String`. This can be use in `struct` definitions like so:
+Enable this to access the module for serializing `Decimal` types to a `String`. This can be use in `struct` definitions like so:
 
 ```rust
 #[derive(Serialize, Deserialize)]
@@ -207,7 +209,7 @@ pub struct StrExample {
 
 ### `serde-with-arbitrary-precision`
 
-Enable this to access the module for serialising `Decimal` types to a `String`. This can be use in `struct` definitions like so:
+Enable this to access the module for serializing `Decimal` types to a `String`. This can be use in `struct` definitions like so:
 
 ```rust
 #[derive(Serialize, Deserialize)]
@@ -216,7 +218,6 @@ pub struct ArbitraryExample {
     value: Decimal,
 }
 ```
-
 
 ### `std`
 
@@ -231,8 +232,6 @@ Please refer to the [Build document](BUILD.md) for more information on building 
 
 The current _minimum_ compiler version is [`1.54.0`](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1540-2021-07-29)
 which was released on `2021-07-29`.
-
-### Updating the minimum supported version
 
 This library maintains support for rust compiler versions that are 4 minor versions away from the current stable rust compiler version.
 For example, if the current stable compiler version is `1.50.0` then we will guarantee support up to and including `1.46.0`.

--- a/VERSION.md
+++ b/VERSION.md
@@ -1,5 +1,13 @@
 # Version History
 
+## 1.21.0
+
+* Saturating op variants have been added: `saturating_add`, `saturating_sub` and `saturating_mul` ([#464](https://github.com/paupino/rust-decimal/pull/464))
+* Fixes issue with `log10` values `0 < x < 1` ([#469](https://github.com/paupino/rust-decimal/pull/469))
+* Various documentation fixes/cleanup.
+
+Thank you [@c410-f3r](https://github.com/c410-f3r) for your work in this release!
+
 ## 1.20.0
 
 * Additional fuzz testing for deserialize ([#452](https://github.com/paupino/rust-decimal/pull/452))

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,44 @@
+use std::{fs, path::PathBuf};
+
+fn main() {
+    println!("cargo:rerun-if-changed=README.md");
+    let readme = fs::read_to_string("README.md").unwrap();
+    let output = PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("README-lib.md");
+    fs::write(output, prepare(&readme)).unwrap();
+}
+
+fn prepare(readme: &String) -> String {
+    // This is a naive implementation to get things off the ground.
+    // We just do a few things for this at the moment:
+    // 1. Strip header stuff
+    // 2. Replace the build document link
+    // 3. Replace serde examples with ignore flags (to avoid feature flagging configuration in docs)
+    let mut cleaned = String::new();
+    let mut body = false;
+    let mut feature_section = false;
+    for line in readme.lines() {
+        if !body {
+            if line.starts_with("[docs]") {
+                body = true;
+            }
+            continue;
+        }
+
+        // Add the line as is, unless it contains "(BUILD.md)"
+        if line.contains("(BUILD.md)") {
+            cleaned.push_str(&line.replace(
+                "(BUILD.md)",
+                "(https://github.com/paupino/rust-decimal/blob/master/BUILD.md)",
+            ));
+        } else if feature_section && line.starts_with("```rust") {
+            cleaned.push_str("```ignore");
+        } else {
+            if !feature_section && line.starts_with("## Features") {
+                feature_section = true;
+            }
+            cleaned.push_str(line);
+        }
+        cleaned.push('\n');
+    }
+    cleaned
+}

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
     fs::write(output, prepare(&readme)).unwrap();
 }
 
-fn prepare(readme: &String) -> String {
+fn prepare(readme: &str) -> String {
     // This is a naive implementation to get things off the ground.
     // We just do a few things for this at the moment:
     // 1. Strip header stuff

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust_decimal_macros"
-version = "1.20.0"
+version = "1.21.0"
 authors = ["Paul Mason <paul@form1.co.nz>"]
 edition = "2018"
 description = "Shorthand macros to assist creating Decimal types."
@@ -12,7 +12,7 @@ categories = ["science","data-structures"]
 license = "MIT"
 
 [dependencies]
-rust_decimal = { path = "..", version = "1.20.0" }
+rust_decimal = { path = "..", version = "1.21.0" }
 quote = "1.0"
 
 [features]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -9,7 +9,7 @@
 //! ```
 //!
 //! While this is convenient for most use cases, it is sometimes not desired behavior when looking
-//! to reexport the libray. Consequently, this behavior can be modified by enabling the feature
+//! to reexport the library. Consequently, this behavior can be modified by enabling the feature
 //! `reexportable`. When this feature is enabled, the macro will instead reproduce the functional
 //! equivalent of:
 //!

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -161,9 +161,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::MIN, dec!(-79_228_162_514_264_337_593_543_950_335));
     /// ```
     pub const MIN: Decimal = MIN;
@@ -173,9 +172,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::MAX, dec!(79_228_162_514_264_337_593_543_950_335));
     /// ```
     pub const MAX: Decimal = MAX;
@@ -185,9 +183,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::ZERO, dec!(0));
     /// ```
     pub const ZERO: Decimal = ZERO;
@@ -197,9 +194,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::ONE, dec!(1));
     /// ```
     pub const ONE: Decimal = ONE;
@@ -209,9 +205,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::NEGATIVE_ONE, dec!(-1));
     /// ```
     pub const NEGATIVE_ONE: Decimal = NEGATIVE_ONE;
@@ -221,9 +216,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::TWO, dec!(2));
     /// ```
     pub const TWO: Decimal = TWO;
@@ -233,9 +227,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::TEN, dec!(10));
     /// ```
     pub const TEN: Decimal = TEN;
@@ -245,9 +238,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::ONE_HUNDRED, dec!(100));
     /// ```
     pub const ONE_HUNDRED: Decimal = ONE_HUNDRED;
@@ -257,9 +249,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::ONE_THOUSAND, dec!(1000));
     /// ```
     pub const ONE_THOUSAND: Decimal = ONE_THOUSAND;
@@ -270,9 +261,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::PI, dec!(3.1415926535897932384626433833));
     /// ```
     #[cfg(feature = "maths")]
@@ -288,9 +278,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::HALF_PI, dec!(1.5707963267948966192313216916));
     /// ```
     #[cfg(feature = "maths")]
@@ -306,9 +295,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::QUARTER_PI, dec!(0.7853981633974483096156608458));
     /// ```
     #[cfg(feature = "maths")]
@@ -324,9 +312,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::TWO_PI, dec!(6.2831853071795864769252867666));
     /// ```
     #[cfg(feature = "maths")]
@@ -342,9 +329,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::E, dec!(2.7182818284590452353602874714));
     /// ```
     #[cfg(feature = "maths")]
@@ -360,9 +346,8 @@ impl Decimal {
     ///
     /// Basic usage:
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use rust_decimal_macros::dec;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
     /// assert_eq!(Decimal::E_INVERSE, dec!(0.3678794411714423215955237702));
     /// ```
     #[cfg(feature = "maths")]
@@ -387,8 +372,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let pi = Decimal::new(3141, 3);
     /// assert_eq!(pi.to_string(), "3.141");
     /// ```
@@ -405,8 +390,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```rust
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let max = Decimal::try_new(i64::MAX, u32::MAX);
     /// assert!(max.is_err());
     /// ```
@@ -446,8 +431,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```rust
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let pi = Decimal::from_i128_with_scale(3141i128, 3);
     /// assert_eq!(pi.to_string(), "3.141");
     /// ```
@@ -465,8 +450,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```rust
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let max = Decimal::try_from_i128_with_scale(i128::MAX, u32::MAX);
     /// assert!(max.is_err());
     /// ```
@@ -513,8 +498,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
     /// assert_eq!(pi.to_string(), "3.1415926535897932384626433832");
     /// ```
@@ -559,10 +544,13 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
-    /// let value = Decimal::from_scientific("9.7e-7").unwrap();
+    /// # use rust_decimal::Decimal;
+    /// #
+    /// # fn main() -> Result<(), rust_decimal::Error> {
+    /// let value = Decimal::from_scientific("9.7e-7")?;
     /// assert_eq!(value.to_string(), "0.00000097");
+    /// #     Ok(())
+    /// # }
     /// ```
     pub fn from_scientific(value: &str) -> Result<Decimal, Error> {
         const ERROR_MESSAGE: &str = "Failed to parse";
@@ -637,8 +625,12 @@ impl Decimal {
     /// Basic usage:
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
-    /// assert_eq!(Decimal::from_str_radix("A", 16).map(|d| d.to_string()), Ok("10".to_string()));
+    /// # use rust_decimal::prelude::*;
+    /// #
+    /// # fn main() -> Result<(), rust_decimal::Error> {
+    /// assert_eq!(Decimal::from_str_radix("A", 16)?.to_string(), "10");
+    /// #     Ok(())
+    /// # }
     /// ```
     pub fn from_str_radix(str: &str, radix: u32) -> Result<Self, crate::Error> {
         if radix == 10 {
@@ -653,8 +645,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let num = Decimal::new(1234, 3);
     /// assert_eq!(num.scale(), 3u32);
     /// ```
@@ -669,9 +661,10 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
+    /// # use rust_decimal::prelude::*;
+    /// use rust_decimal_macros::dec;
     ///
-    /// let num = Decimal::from_str("-1.2345678").unwrap();
+    /// let num = dec!(-1.2345678);
     /// assert_eq!(num.mantissa(), -12345678i128);
     /// assert_eq!(num.scale(), 7);
     /// ```
@@ -690,8 +683,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
-    ///
+    /// # use rust_decimal::prelude::*;
+    /// #
     /// let num = Decimal::ZERO;
     /// assert!(num.is_zero());
     /// ```
@@ -709,8 +702,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let mut one = Decimal::ONE;
     /// one.set_sign(false);
     /// assert_eq!(one.to_string(), "-1");
@@ -729,8 +722,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let mut one = Decimal::ONE;
     /// one.set_sign_positive(false);
     /// assert_eq!(one.to_string(), "-1");
@@ -753,8 +746,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let mut one = Decimal::ONE;
     /// one.set_sign_negative(true);
     /// assert_eq!(one.to_string(), "-1");
@@ -773,11 +766,14 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
+    /// # fn main() -> Result<(), rust_decimal::Error> {
     /// let mut one = Decimal::ONE;
-    /// one.set_scale(5).unwrap();
+    /// one.set_scale(5)?;
     /// assert_eq!(one.to_string(), "0.00001");
+    /// #    Ok(())
+    /// # }
     /// ```
     pub fn set_scale(&mut self, scale: u32) -> Result<(), Error> {
         if scale > MAX_PRECISION_U32 {
@@ -803,17 +799,18 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
+    /// # use rust_decimal::prelude::*;
+    /// use rust_decimal_macros::dec;
     ///
     /// // Rescaling to a higher scale preserves the value
-    /// let mut number = Decimal::from_str("1.123").unwrap();
+    /// let mut number = dec!(1.123);
     /// assert_eq!(number.scale(), 3);
     /// number.rescale(6);
     /// assert_eq!(number.to_string(), "1.123000");
     /// assert_eq!(number.scale(), 6);
     ///
     /// // Rescaling to a lower scale forces the number to be rounded
-    /// let mut number = Decimal::from_str("1.45").unwrap();
+    /// let mut number = dec!(1.45);
     /// assert_eq!(number.scale(), 2);
     /// number.rescale(1);
     /// assert_eq!(number.to_string(), "1.5");
@@ -821,7 +818,7 @@ impl Decimal {
     ///
     /// // This function never fails. Consequently, if a scale is provided that is unable to be
     /// // represented using the given mantissa, then the maximum possible scale is used.
-    /// let mut number = Decimal::from_str("11.76470588235294").unwrap();
+    /// let mut number = dec!(11.76470588235294);
     /// assert_eq!(number.scale(), 14);
     /// number.rescale(28);
     /// // A scale of 28 cannot be represented given this mantissa, however it was able to represent
@@ -924,12 +921,28 @@ impl Decimal {
     }
 
     /// Returns `true` if the sign bit of the decimal is negative.
+    ///
+    /// # Example
+    /// ```
+    /// # use rust_decimal::prelude::*;
+    /// #
+    /// assert_eq!(true, Decimal::new(-1, 0).is_sign_negative());
+    /// assert_eq!(false, Decimal::new(1, 0).is_sign_negative());
+    /// ```
     #[inline(always)]
     pub const fn is_sign_negative(&self) -> bool {
         self.flags & SIGN_MASK > 0
     }
 
     /// Returns `true` if the sign bit of the decimal is positive.
+    ///
+    /// # Example
+    /// ```
+    /// # use rust_decimal::prelude::*;
+    /// #
+    /// assert_eq!(false, Decimal::new(-1, 0).is_sign_positive());
+    /// assert_eq!(true, Decimal::new(1, 0).is_sign_positive());
+    /// ```
     #[inline(always)]
     #[must_use]
     pub const fn is_sign_positive(&self) -> bool {
@@ -956,8 +969,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let pi = Decimal::new(3141, 3);
     /// let trunc = Decimal::new(3, 0);
     /// // note that it returns a decimal
@@ -995,8 +1008,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let pi = Decimal::new(3141, 3);
     /// let fract = Decimal::new(141, 3);
     /// // note that it returns a decimal
@@ -1014,8 +1027,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let num = Decimal::new(-3141, 3);
     /// assert_eq!(num.abs().to_string(), "3.141");
     /// ```
@@ -1031,8 +1044,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let num = Decimal::new(3641, 3);
     /// assert_eq!(num.floor().to_string(), "3");
     /// ```
@@ -1058,8 +1071,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let num = Decimal::new(3141, 3);
     /// assert_eq!(num.ceil().to_string(), "4");
     /// let num = Decimal::new(3, 0);
@@ -1084,8 +1097,8 @@ impl Decimal {
     /// Returns the maximum of the two numbers.
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let x = Decimal::new(1, 0);
     /// let y = Decimal::new(2, 0);
     /// assert_eq!(y, x.max(y));
@@ -1102,8 +1115,8 @@ impl Decimal {
     /// Returns the minimum of the two numbers.
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// let x = Decimal::new(1, 0);
     /// let y = Decimal::new(2, 0);
     /// assert_eq!(x, x.min(y));
@@ -1122,10 +1135,12 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
-    ///
-    /// let number = Decimal::from_str("3.100").unwrap();
+    /// # use rust_decimal::prelude::*;
+    /// # fn main() -> Result<(), rust_decimal::Error> {
+    /// let number = Decimal::from_str("3.100")?;
     /// assert_eq!(number.normalize().to_string(), "3.1");
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn normalize(&self) -> Decimal {
@@ -1139,12 +1154,14 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
-    ///
-    /// let mut number = Decimal::from_str("3.100").unwrap();
+    /// # use rust_decimal::prelude::*;
+    /// # fn main() -> Result<(), rust_decimal::Error> {
+    /// let mut number = Decimal::from_str("3.100")?;
     /// assert_eq!(number.to_string(), "3.100");
     /// number.normalize_assign();
     /// assert_eq!(number.to_string(), "3.1");
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn normalize_assign(&mut self) {
         if self.is_zero() {
@@ -1178,8 +1195,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    ///
+    /// # use rust_decimal::Decimal;
+    /// #
     /// // Demonstrating bankers rounding...
     /// let number_down = Decimal::new(65, 1);
     /// let number_up   = Decimal::new(75, 1);
@@ -1202,10 +1219,10 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::{Decimal, RoundingStrategy};
-    /// use core::str::FromStr;
-    ///
-    /// let tax = Decimal::from_str("3.4395").unwrap();
+    /// # use rust_decimal::{Decimal, RoundingStrategy};
+    /// # use rust_decimal_macros::dec;
+    /// #
+    /// let tax = dec!(3.4395);
     /// assert_eq!(tax.round_dp_with_strategy(2, RoundingStrategy::MidpointAwayFromZero).to_string(), "3.44");
     /// ```
     #[must_use]
@@ -1355,10 +1372,10 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use core::str::FromStr;
-    ///
-    /// let pi = Decimal::from_str("3.1415926535897932384626433832").unwrap();
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
+    /// #
+    /// let pi = dec!(3.1415926535897932384626433832);
     /// assert_eq!(pi.round_dp(2).to_string(), "3.14");
     /// ```
     #[must_use]
@@ -1385,22 +1402,22 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use core::str::FromStr;
+    /// # use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
     ///
-    /// let value = Decimal::from_str("305.459").unwrap();
-    /// assert_eq!(value.round_sf(0), Some(Decimal::from_str("0").unwrap()));
-    /// assert_eq!(value.round_sf(1), Some(Decimal::from_str("300").unwrap()));
-    /// assert_eq!(value.round_sf(2), Some(Decimal::from_str("310").unwrap()));
-    /// assert_eq!(value.round_sf(3), Some(Decimal::from_str("305").unwrap()));
-    /// assert_eq!(value.round_sf(4), Some(Decimal::from_str("305.5").unwrap()));
-    /// assert_eq!(value.round_sf(5), Some(Decimal::from_str("305.46").unwrap()));
-    /// assert_eq!(value.round_sf(6), Some(Decimal::from_str("305.459").unwrap()));
-    /// assert_eq!(value.round_sf(7), Some(Decimal::from_str("305.4590").unwrap()));
+    /// let value = dec!(305.459);
+    /// assert_eq!(value.round_sf(0), Some(dec!(0)));
+    /// assert_eq!(value.round_sf(1), Some(dec!(300)));
+    /// assert_eq!(value.round_sf(2), Some(dec!(310)));
+    /// assert_eq!(value.round_sf(3), Some(dec!(305)));
+    /// assert_eq!(value.round_sf(4), Some(dec!(305.5)));
+    /// assert_eq!(value.round_sf(5), Some(dec!(305.46)));
+    /// assert_eq!(value.round_sf(6), Some(dec!(305.459)));
+    /// assert_eq!(value.round_sf(7), Some(dec!(305.4590)));
     /// assert_eq!(Decimal::MAX.round_sf(1), None);
     ///
-    /// let value = Decimal::from_str("0.012301").unwrap();
-    /// assert_eq!(value.round_sf(3), Some(Decimal::from_str("0.0123").unwrap()));
+    /// let value = dec!(0.012301);
+    /// assert_eq!(value.round_sf(3), Some(dec!(0.0123)));
     /// ```
     #[must_use]
     pub fn round_sf(&self, digits: u32) -> Option<Decimal> {
@@ -1427,22 +1444,22 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::{Decimal, RoundingStrategy};
-    /// use core::str::FromStr;
+    /// # use rust_decimal::{Decimal, RoundingStrategy};
+    /// use rust_decimal_macros::dec;
     ///
-    /// let value = Decimal::from_str("305.459").unwrap();
-    /// assert_eq!(value.round_sf_with_strategy(0, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("0").unwrap());
-    /// assert_eq!(value.round_sf_with_strategy(1, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("300").unwrap());
-    /// assert_eq!(value.round_sf_with_strategy(2, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("300").unwrap());
-    /// assert_eq!(value.round_sf_with_strategy(3, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("305").unwrap());
-    /// assert_eq!(value.round_sf_with_strategy(4, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("305.4").unwrap());
-    /// assert_eq!(value.round_sf_with_strategy(5, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("305.45").unwrap());
-    /// assert_eq!(value.round_sf_with_strategy(6, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("305.459").unwrap());
-    /// assert_eq!(value.round_sf_with_strategy(7, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("305.4590").unwrap());
-    /// assert_eq!(Decimal::MAX.round_sf_with_strategy(1, RoundingStrategy::ToZero).unwrap(), Decimal::from_str("70000000000000000000000000000").unwrap());
+    /// let value = dec!(305.459);
+    /// assert_eq!(value.round_sf_with_strategy(0, RoundingStrategy::ToZero), Some(dec!(0)));
+    /// assert_eq!(value.round_sf_with_strategy(1, RoundingStrategy::ToZero), Some(dec!(300)));
+    /// assert_eq!(value.round_sf_with_strategy(2, RoundingStrategy::ToZero), Some(dec!(300)));
+    /// assert_eq!(value.round_sf_with_strategy(3, RoundingStrategy::ToZero), Some(dec!(305)));
+    /// assert_eq!(value.round_sf_with_strategy(4, RoundingStrategy::ToZero), Some(dec!(305.4)));
+    /// assert_eq!(value.round_sf_with_strategy(5, RoundingStrategy::ToZero), Some(dec!(305.45)));
+    /// assert_eq!(value.round_sf_with_strategy(6, RoundingStrategy::ToZero), Some(dec!(305.459)));
+    /// assert_eq!(value.round_sf_with_strategy(7, RoundingStrategy::ToZero), Some(dec!(305.4590)));
+    /// assert_eq!(Decimal::MAX.round_sf_with_strategy(1, RoundingStrategy::ToZero), Some(dec!(70000000000000000000000000000)));
     ///
-    /// let value = Decimal::from_str("0.012301").unwrap();
-    /// assert_eq!(value.round_sf_with_strategy(3, RoundingStrategy::AwayFromZero), Some(Decimal::from_str("0.0124").unwrap()));
+    /// let value = dec!(0.012301);
+    /// assert_eq!(value.round_sf_with_strategy(3, RoundingStrategy::AwayFromZero), Some(dec!(0.0124)));
     /// ```
     #[must_use]
     pub fn round_sf_with_strategy(&self, digits: u32, strategy: RoundingStrategy) -> Option<Decimal> {
@@ -1539,10 +1556,10 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::Decimal;
-    /// use core::str::FromStr;
+    /// # use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
     ///
-    /// let pi = Decimal::from_str("3.1415926535897932384626433832").unwrap();
+    /// let pi = dec!(3.1415926535897932384626433832);
     /// assert_eq!(format!("{:?}", pi), "3.1415926535897932384626433832");
     /// assert_eq!(format!("{:?}", pi.unpack()), "UnpackedDecimal { \
     ///     negative: false, scale: 28, hi: 1703060790, mid: 185874565, lo: 1102470952 \
@@ -1597,8 +1614,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
-    ///
+    /// # use rust_decimal::prelude::*;
+    /// #
     /// // Usually floats are parsed leveraging float guarantees. i.e. 0.1_f32 => 0.1
     /// assert_eq!("0.1", Decimal::from_f32(0.1_f32).unwrap().to_string());
     ///
@@ -1618,8 +1635,8 @@ impl Decimal {
     /// # Example
     ///
     /// ```
-    /// use rust_decimal::prelude::*;
-    ///
+    /// # use rust_decimal::prelude::*;
+    /// #
     /// // Usually floats are parsed leveraging float guarantees. i.e. 0.1_f64 => 0.1
     /// assert_eq!("0.1", Decimal::from_f64(0.1_f64).unwrap().to_string());
     ///

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -156,25 +156,125 @@ pub enum RoundingStrategy {
 #[allow(dead_code)]
 impl Decimal {
     /// The smallest value that can be represented by this decimal type.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::MIN, dec!(-79_228_162_514_264_337_593_543_950_335));
+    /// ```
     pub const MIN: Decimal = MIN;
     /// The largest value that can be represented by this decimal type.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::MAX, dec!(79_228_162_514_264_337_593_543_950_335));
+    /// ```
     pub const MAX: Decimal = MAX;
     /// A constant representing 0.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::ZERO, dec!(0));
+    /// ```
     pub const ZERO: Decimal = ZERO;
     /// A constant representing 1.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::ONE, dec!(1));
+    /// ```
     pub const ONE: Decimal = ONE;
     /// A constant representing -1.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::NEGATIVE_ONE, dec!(-1));
+    /// ```
     pub const NEGATIVE_ONE: Decimal = NEGATIVE_ONE;
     /// A constant representing 2.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::TWO, dec!(2));
+    /// ```
     pub const TWO: Decimal = TWO;
     /// A constant representing 10.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::TEN, dec!(10));
+    /// ```
     pub const TEN: Decimal = TEN;
     /// A constant representing 100.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::ONE_HUNDRED, dec!(100));
+    /// ```
     pub const ONE_HUNDRED: Decimal = ONE_HUNDRED;
     /// A constant representing 1000.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::ONE_THOUSAND, dec!(1000));
+    /// ```
     pub const ONE_THOUSAND: Decimal = ONE_THOUSAND;
 
     /// A constant representing π as 3.1415926535897932384626433833
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::PI, dec!(3.1415926535897932384626433833));
+    /// ```
     #[cfg(feature = "maths")]
     pub const PI: Decimal = Decimal {
         flags: 1835008,
@@ -183,6 +283,16 @@ impl Decimal {
         hi: 1703060790,
     };
     /// A constant representing π/2 as 1.5707963267948966192313216916
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::HALF_PI, dec!(1.5707963267948966192313216916));
+    /// ```
     #[cfg(feature = "maths")]
     pub const HALF_PI: Decimal = Decimal {
         flags: 1835008,
@@ -191,6 +301,16 @@ impl Decimal {
         hi: 851530395,
     };
     /// A constant representing π/4 as 0.7853981633974483096156608458
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::QUARTER_PI, dec!(0.7853981633974483096156608458));
+    /// ```
     #[cfg(feature = "maths")]
     pub const QUARTER_PI: Decimal = Decimal {
         flags: 1835008,
@@ -199,6 +319,16 @@ impl Decimal {
         hi: 425765197,
     };
     /// A constant representing 2π as 6.2831853071795864769252867666
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::TWO_PI, dec!(6.2831853071795864769252867666));
+    /// ```
     #[cfg(feature = "maths")]
     pub const TWO_PI: Decimal = Decimal {
         flags: 1835008,
@@ -207,6 +337,16 @@ impl Decimal {
         hi: 3406121580,
     };
     /// A constant representing Euler's number (e) as 2.7182818284590452353602874714
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::E, dec!(2.7182818284590452353602874714));
+    /// ```
     #[cfg(feature = "maths")]
     pub const E: Decimal = Decimal {
         flags: 1835008,
@@ -215,6 +355,16 @@ impl Decimal {
         hi: 1473583531,
     };
     /// A constant representing the inverse of Euler's number (1/e) as 0.3678794411714423215955237702
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// use rust_decimal::Decimal;
+    /// use rust_decimal_macros::dec;
+    ///
+    /// assert_eq!(Decimal::E_INVERSE, dec!(0.3678794411714423215955237702));
+    /// ```
     #[cfg(feature = "maths")]
     pub const E_INVERSE: Decimal = Decimal {
         flags: 1835008,
@@ -470,6 +620,32 @@ impl Decimal {
             }
         }
         Ok(ret)
+    }
+
+    /// Converts a string slice in a given base to a decimal.
+    ///
+    /// The string is expected to be an optional + sign followed by digits.
+    /// Digits are a subset of these characters, depending on radix, and will return an error if outside
+    /// the expected range:
+    ///
+    /// * 0-9
+    /// * a-z
+    /// * A-Z
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use rust_decimal::prelude::*;
+    /// assert_eq!(Decimal::from_str_radix("A", 16).map(|d| d.to_string()), Ok("10".to_string()));
+    /// ```
+    pub fn from_str_radix(str: &str, radix: u32) -> Result<Self, crate::Error> {
+        if radix == 10 {
+            crate::str::parse_str_radix_10(str)
+        } else {
+            crate::str::parse_str_radix_n(str, radix)
+        }
     }
 
     /// Returns the scale of the decimal number, otherwise known as `e`.
@@ -1452,14 +1628,6 @@ impl Decimal {
     /// ```
     pub fn from_f64_retain(n: f64) -> Option<Self> {
         from_f64(n, false)
-    }
-
-    pub fn from_str_radix(str: &str, radix: u32) -> Result<Self, crate::Error> {
-        if radix == 10 {
-            crate::str::parse_str_radix_10(str)
-        } else {
-            crate::str::parse_str_radix_n(str, radix)
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,170 +1,4 @@
-//!
-//! A Decimal implementation written in pure Rust suitable
-//! for financial calculations that require significant integral
-//! and fractional digits with no round-off errors.
-//!
-//! The binary representation consists of a 96 bit integer number,
-//! a scaling factor used to specify the decimal fraction and a 1
-//! bit sign. Because of this representation, trailing zeros are
-//! preserved and may be exposed when in string form. These can be
-//! truncated using the `normalize` or `round_dp` functions.
-//!
-//! ## Getting started
-//!
-//! To get started, add `rust_decimal` and optionally `rust_decimal_macros` to your `Cargo.toml`:
-//!
-//! ```toml
-//! [dependencies]
-//! rust_decimal = "1.20"
-//! rust_decimal_macros = "1.20"
-//! ```
-//!
-//! ## Usage
-//!
-//! Decimal numbers can be created in a few distinct ways. The easiest and most optimal
-//! method of creating a Decimal is to use the procedural macro within the
-//! `rust_decimal_macros` crate:
-//!
-//! ```ignore
-//! // Procedural macros need importing directly
-//! use rust_decimal_macros::dec;
-//!
-//! let number = dec!(-1.23);
-//! assert_eq!("-1.23", number.to_string());
-//! ```
-//!
-//! Alternatively you can also use one of the Decimal number convenience functions:
-//!
-//! ```rust
-//! // Using the prelude can help importing trait based functions (e.g. core::str::FromStr).
-//! use rust_decimal::prelude::*;
-//!
-//! // Using an integer followed by the decimal points
-//! let scaled = Decimal::new(202, 2);
-//! assert_eq!("2.02", scaled.to_string());
-//!
-//! // From a string representation
-//! let from_string = Decimal::from_str("2.02").unwrap();
-//! assert_eq!("2.02", from_string.to_string());
-//!
-//! // From a string representation in a different base
-//! let from_string_base16 = Decimal::from_str_radix("ffff", 16).unwrap();
-//! assert_eq!("65535", from_string_base16.to_string());
-//!
-//! // Using the `Into` trait
-//! let my_int: Decimal = 3i32.into();
-//! assert_eq!("3", my_int.to_string());
-//!
-//! // Using the raw decimal representation
-//! let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
-//! assert_eq!("3.1415926535897932384626433832", pi.to_string());
-//! ```
-//!
-//! Once you have instantiated your `Decimal` number you can perform calculations with it just like any other number:
-//!
-//! ```rust
-//! use rust_decimal::prelude::*;
-//!
-//! let amount = Decimal::from_str("25.12").unwrap();
-//! let tax = Decimal::from_str("0.085").unwrap();
-//! let total = amount + (amount * tax).round_dp(2);
-//! assert_eq!(total.to_string(), "27.26");
-//! ```
-//!
-//! ## Features
-//!
-//! * [c-repr](#c-repr)
-//! * [db-postgres](#db-postgres)
-//! * [db-tokio-postgres](#db-tokio-postgres)
-//! * [db-diesel-postgres](#db-diesel-postgres)
-//! * [legacy-ops](#legacy-ops)
-//! * [maths](#maths)
-//! * [rocket-traits](#rocket-traits)
-//! * [rust-fuzz](#rust-fuzz)
-//! * [serde-float](#serde-float)
-//! * [serde-str](#serde-str)
-//! * [serde-arbitrary-precision](#serde-arbitrary-precision)
-//! * [std](#std)
-//!
-//! ### `c-repr`
-//!
-//! Forces `Decimal` to use `[repr(C)]`. The corresponding target layout is 128 bit aligned.
-//!
-//! ### `db-postgres`
-//!
-//! This feature enables a PostgreSQL communication module. It allows for reading and writing the `Decimal`
-//! type by transparently serializing/deserializing into the `NUMERIC` data type within PostgreSQL.
-//!
-//! ### `db-tokio-postgres`
-//!
-//! Enables the tokio postgres module allowing for async communication with PostgreSQL.
-//!
-//! ### `db-diesel-postgres`
-//!
-//! Enable `diesel` PostgreSQL support.
-//!
-//! ### `legacy-ops`
-//!
-//! As of `1.10` the algorithms used to perform basic operations have changed which has benefits of significant speed improvements.
-//! To maintain backwards compatibility this can be opted out of by enabling the `legacy-ops` feature.
-//!
-//! ### `maths`
-//!
-//! The `maths` feature enables additional complex mathematical functions such as `pow`, `ln`, `enf`, `exp` etc.
-//! Documentation detailing the additional functions can be found on the
-//! [`MathematicalOps`](https://docs.rs/rust_decimal/latest/rust_decimal/trait.MathematicalOps.html) trait.
-//!
-//! Please note that `ln` and `log10` will panic on invalid input with `checked_ln` and `checked_log10` the preferred functions
-//! to curb against this. When the `maths` feature was first developed the library would return `0` on invalid input. To re-enable this
-//! non-panicing behavior, please use the feature: `maths-nopanic`.
-//!
-//! ### `rocket-traits`
-//!
-//! Enable support for forms by implementing the `FromFormField` trait.
-//!
-//! ### `rust-fuzz`
-//!
-//! Enable `rust-fuzz` support by implementing the `Arbitrary` trait.
-//!
-//! ### `serde-float`
-//!
-//! Enable this so that JSON serialization of `Decimal` types are sent as a float instead of a string (default).
-//!
-//! e.g. with this turned on, JSON serialization would output:
-//! ```json
-//! {
-//!   "value": 1.234
-//! }
-//! ```
-//!
-//! ### `serde-str`
-//!
-//! This is typically useful for `bincode` or `csv` like implementations.
-//!
-//! Since `bincode` does not specify type information, we need to ensure that a type hint is provided in order to
-//! correctly be able to deserialize. Enabling this feature on its own will force deserialization to use `deserialize_str`
-//! instead of `deserialize_any`.
-//!
-//! If, for some reason, you also have `serde-float` enabled then this will use `deserialize_f64` as a type hint. Because
-//! converting to `f64` _loses_ precision, it's highly recommended that you do NOT enable this feature when working with
-//! `bincode`. That being said, this will only use 8 bytes so is slightly more efficient in terms of storage size.
-//!
-//! ### `serde-arbitrary-precision`
-//!
-//! This is used primarily with `serde_json` and consequently adds it as a "weak dependency". This supports the
-//! `arbitrary_precision` feature inside `serde_json` when parsing decimals.
-//!
-//! This is recommended when parsing "float" looking data as it will prevent data loss.
-//!
-//! ### `std`
-//!
-//! Enable `std` library support. This is enabled by default, however in the future will be opt in. For now, to support `no_std`
-//! libraries, this crate can be compiled with `--no-default-features`.
-//!
-//! ## Building
-//!
-//! Please refer to the [Build document](BUILD.md) for more information on building and testing Rust Decimal.
-//!
+#![doc = include_str!(concat!(env!("OUT_DIR"), "/README-lib.md"))]
 #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
 extern crate alloc;
@@ -192,7 +26,24 @@ mod mysql;
 mod postgres;
 #[cfg(feature = "rocket-traits")]
 mod rocket;
-#[cfg(feature = "serde")]
+#[cfg(all(
+    feature = "serde",
+    not(any(
+        feature = "serde-with-str",
+        feature = "serde-with-float",
+        feature = "serde-with-arbitrary-precision"
+    ))
+))]
+mod serde;
+/// Serde specific functionality to customize how a decimal is serialized/deserialized (`serde_with`)
+#[cfg(all(
+    feature = "serde",
+    any(
+        feature = "serde-with-str",
+        feature = "serde-with-float",
+        feature = "serde-with-arbitrary-precision"
+    )
+))]
 pub mod serde;
 
 pub use decimal::{Decimal, RoundingStrategy};
@@ -216,3 +67,6 @@ extern crate diesel;
 /// Shortcut for `core::result::Result<T, rust_decimal::Error>`. Useful to distinguish
 /// between `rust_decimal` and `std` types.
 pub type Result<T> = core::result::Result<T, Error>;
+
+// #[cfg(feature = "legacy-ops")]
+// compiler_error!("legacy-ops has been removed as 1.x");

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -331,7 +331,7 @@ impl serde::Serialize for Decimal {
 #[cfg(test)]
 mod test {
     use super::*;
-    use serde_derive::{Deserialize, Serialize};
+    use serde::{Deserialize, Serialize};
 
     #[derive(Serialize, Deserialize, Debug)]
     struct Record {


### PR DESCRIPTION
Includes a bit of a documentation clean up with further examples added. I'm opting to start using `dec!` in doc examples too, however that can be rolled out slowly. The downside is the extra import line each time - I wonder if there is a way to import for all doc tests?