### PR TITLE
Borsh Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ rocket = { default-features = false, optional = true, version = "0.5.0-rc.1" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
+borsh = { default-features = false, optional = true, version = "0.9.3" }
 
 [dev-dependencies]
 bincode = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ all-features = true
 [dependencies]
 arbitrary = { default-features = false, optional = true, version = "1.0" }
 arrayvec = { default-features = false, version = "0.7" }
+borsh = { default-features = false, optional = true, version = "0.9.3" }
 byteorder = { default-features = false, optional = true, version = "1.3" }
 bytes = { default-features = false, optional = true, version = "1.0" }
 diesel = { default-features = false, optional = true, version = "1.4" }
@@ -33,7 +34,6 @@ rocket = { default-features = false, optional = true, version = "0.5.0-rc.1" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
-borsh = { default-features = false, optional = true, version = "0.9.3" }
 
 [dev-dependencies]
 bincode = "1.3"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -118,7 +118,8 @@ dependencies = [
     "test-db",
     "test-rocket-traits",
     "test-serde",
-    "test-macros"
+    "test-macros",
+    "test-borsh"
 ]
 
 [tasks.test-db]
@@ -240,3 +241,8 @@ args = ["test", "--workspace", "--tests", "--features=serde-with-float", "serde"
 [tasks.test-serde-with-str]
 command = "cargo"
 args = ["test", "--workspace", "--tests", "--features=serde-with-str", "serde", "--", "--skip", "generated"]
+
+[tasks.test-borsh]
+command = "cargo"
+args = ["test", "--workspace", "--features=borsh"]
+

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ assert_eq!(total.to_string(), "27.26");
 
 **Behavior / Functionality**
 
+* [borsh](#borsh)
 * [c-repr](#c-repr)
 * [legacy-ops](#legacy-ops)
 * [maths](#maths)
@@ -97,6 +98,9 @@ assert_eq!(total.to_string(), "27.26");
 * [serde-with-float](#serde-with-float)
 * [serde-with-str](#serde-with-str)
 * [serde-with-arbitrary-precision](#serde-with-arbitrary-precision)
+
+### `borsh`
+Enables [Borsh](https://borsh.io/) serialization for `Decimal`.
 
 ### `c-repr`
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -19,8 +19,6 @@ use diesel::sql_types::Numeric;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
-#[cfg(feature = "borsh")]
-use borsh::{BorshDeserialize, BorshSerialize};
 
 /// The smallest value that can be represented by this decimal type.
 const MIN: Decimal = Decimal {
@@ -99,7 +97,7 @@ pub struct UnpackedDecimal {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
 #[cfg_attr(feature = "c-repr", repr(C))]
-#[cfg_attr(feature = "borsh", derive(BorshDeserialize, BorshSerialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshDeserialize, borsh::BorshSerialize))]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -19,6 +19,8 @@ use diesel::sql_types::Numeric;
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+#[cfg(feature = "borsh")]
+use borsh::{BorshDeserialize, BorshSerialize};
 
 /// The smallest value that can be represented by this decimal type.
 const MIN: Decimal = Decimal {
@@ -97,6 +99,7 @@ pub struct UnpackedDecimal {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
 #[cfg_attr(feature = "c-repr", repr(C))]
+#[cfg_attr(feature = "borsh", derive(BorshDeserialize, BorshSerialize))]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -133,6 +133,23 @@ fn it_can_serialize_deserialize() {
 }
 
 #[test]
+#[cfg(feature = "borsh")]
+fn it_can_serialize_deserialize_borsh() {
+    let tests = [
+        "12.3456789",
+        "5233.9008808150288439427720175",
+        "-5233.9008808150288439427720175",
+    ];
+    for test in &tests {
+        let a = Decimal::from_str(test).unwrap();
+        let mut bytes: Vec<u8> = Vec::new();
+        borsh::BorshSerialize::serialize(&a, &mut bytes).unwrap();
+        let b: Decimal = borsh::BorshDeserialize::deserialize(&mut bytes.as_slice()).unwrap();
+        assert_eq!(test.to_string(), b.to_string());
+    }
+}
+
+#[test]
 fn it_can_deserialize_unbounded_values() {
     // Mantissa for these: 19393111376951473493673267553
     let tests = [


### PR DESCRIPTION
Adding support for Borsh serialization via an optional crate feature.
I've only added this to the Decimal object so far, please let me know where else to add this needs to be supported.