### PR TITLE
Fix Decimal::to_i64 for I64::MIN

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2127,14 +2127,14 @@ impl ToPrimitive for Decimal {
     fn to_i64(&self) -> Option<i64> {
         let d = self.trunc();
         // Quick overflow check
-        if d.hi != 0 || (d.mid & 0x8000_0000) > 0 {
+        if d.hi != 0 || (d.is_sign_positive() && (d.mid & 0x8000_0000) > 0) {
             // Overflow
             return None;
         }
 
         let raw: i64 = (i64::from(d.mid) << 32) | i64::from(d.lo);
         if self.is_sign_negative() {
-            Some(-raw)
+            Some(raw.wrapping_neg())
         } else {
             Some(raw)
         }

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -2638,10 +2638,15 @@ fn it_converts_to_i64() {
     assert_eq!(5i64, Decimal::from_str("5.12345").unwrap().to_i64().unwrap());
     assert_eq!(-5i64, Decimal::from_str("-5.12345").unwrap().to_i64().unwrap());
     assert_eq!(
-        0x7FFF_FFFF_FFFF_FFFF,
-        Decimal::from_str("9223372036854775807").unwrap().to_i64().unwrap()
+        Some(i64::MIN),
+        Decimal::from_str("-9223372036854775808").unwrap().to_i64()
     );
-    assert_eq!(None, Decimal::from_str("92233720368547758089").unwrap().to_i64());
+    assert_eq!(
+        Some(i64::MAX),
+        Decimal::from_str("9223372036854775807").unwrap().to_i64()
+    );
+    assert_eq!(None, Decimal::from_str("-92233720368547758089").unwrap().to_i64());
+    assert_eq!(None, Decimal::from_str("92233720368547758088").unwrap().to_i64());
 }
 
 #[test]


### PR DESCRIPTION
The overflow check didn't consider that the maximum mantissa for negative numbers can use the extra bit.