### PR TITLE
implement borsh schema

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -97,7 +97,7 @@ pub struct UnpackedDecimal {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
 #[cfg_attr(feature = "c-repr", repr(C))]
-#[cfg_attr(feature = "borsh", derive(borsh::BorshDeserialize, borsh::BorshSerialize))]
+#[cfg_attr(feature = "borsh", derive(borsh::BorshDeserialize, borsh::BorshSerialize, borsh::BorshSchema))]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -97,7 +97,10 @@ pub struct UnpackedDecimal {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
 #[cfg_attr(feature = "c-repr", repr(C))]
-#[cfg_attr(feature = "borsh", derive(borsh::BorshDeserialize, borsh::BorshSerialize, borsh::BorshSchema))]
+#[cfg_attr(
+    feature = "borsh",
+    derive(borsh::BorshDeserialize, borsh::BorshSerialize, borsh::BorshSchema)
+)]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -147,6 +147,7 @@ fn it_can_serialize_deserialize_borsh() {
         let b: Decimal = borsh::BorshDeserialize::deserialize(&mut bytes.as_slice()).unwrap();
         assert_eq!(test.to_string(), b.to_string());
     }
+    let _it_has_a_schema = <Decimal as BorshSchema>::schema_container();
 }
 
 #[test]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -146,8 +146,10 @@ fn it_can_serialize_deserialize_borsh() {
         borsh::BorshSerialize::serialize(&a, &mut bytes).unwrap();
         let b: Decimal = borsh::BorshDeserialize::deserialize(&mut bytes.as_slice()).unwrap();
         assert_eq!(test.to_string(), b.to_string());
+	let bytes = borsh::schema_helper::serialize_with_schema(&a);
+	let b: Decimal = borsh::schema_helper::deserialize_with_schema(&bytes);
+        assert_eq!(test.to_string(), b.to_string());
     }
-    let _it_has_a_schema = <Decimal as BorshSchema>::schema_container();
 }
 
 #[test]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -146,8 +146,8 @@ fn it_can_serialize_deserialize_borsh() {
         borsh::BorshSerialize::serialize(&a, &mut bytes).unwrap();
         let b: Decimal = borsh::BorshDeserialize::deserialize(&mut bytes.as_slice()).unwrap();
         assert_eq!(test.to_string(), b.to_string());
-	let bytes = borsh::schema_helper::serialize_with_schema(&a);
-	let b: Decimal = borsh::schema_helper::deserialize_with_schema(&bytes);
+        let bytes = borsh::schema_helper::serialize_with_schema(&a);
+        let b: Decimal = borsh::schema_helper::deserialize_with_schema(&bytes);
         assert_eq!(test.to_string(), b.to_string());
     }
 }


### PR DESCRIPTION
I would like to use rust_decimal with BorshSchema.
There’s nothing to do but deriving from an extra trait when the feature is active, so that should not impact existing users.