### PR TITLE
Fixes issue with workspace build always including default

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["science","data-structures"]
 license = "MIT"
 
 [dependencies]
-rust_decimal = { path = "..", version = "1.23.1" }
+rust_decimal = { path = "..", version = "1.23.1", default-features = false }
 quote = "1.0"
 
 [dev-dependencies]

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -748,6 +748,9 @@ impl Pow<f64> for Decimal {
 mod test {
     use super::*;
 
+    #[cfg(not(feature = "std"))]
+    use alloc::string::ToString;
+
     #[test]
     fn test_factorials() {
         assert_eq!("1", FACTORIAL[0].to_string(), "0!");

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -146,8 +146,12 @@ fn it_can_serialize_deserialize_borsh() {
         borsh::BorshSerialize::serialize(&a, &mut bytes).unwrap();
         let b: Decimal = borsh::BorshDeserialize::deserialize(&mut bytes.as_slice()).unwrap();
         assert_eq!(test.to_string(), b.to_string());
-        let bytes = borsh::schema_helper::serialize_with_schema(&a);
-        let b: Decimal = borsh::schema_helper::deserialize_with_schema(&bytes);
+        let bytes = borsh::try_to_vec_with_schema(&a);
+        assert!(bytes.is_ok(), "try_to_vec_with_schema.is_ok()");
+        let bytes = bytes.unwrap();
+        let result = borsh::try_from_slice_with_schema(&bytes);
+        assert!(result.is_ok(), "try_from_slice_with_schema.is_ok()");
+        let b: Decimal = result.unwrap();
         assert_eq!(test.to_string(), b.to_string());
     }
 }


### PR DESCRIPTION
This resolves an issue with `no_std` tests not actually executing under the right context due to the workspace build automatically resolving and including the `default` feature. 