### PR TITLE
Enable borsh tests on github actions

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -118,8 +118,7 @@ dependencies = [
     "test-db",
     "test-rocket-traits",
     "test-serde",
-    "test-macros",
-    "test-borsh"
+    "test-macros"
 ]
 
 [tasks.test-db]
@@ -175,6 +174,12 @@ command = "cargo"
 args = ["test", "--workspace", "--no-default-features", "--features=maths-nopanic", "maths", "--", "--skip", "generated"]
 
 [tasks.test-misc]
+dependencies = [
+    "test-rust-fuzz",
+    "test-borsh"
+]
+
+[tasks.test-rust-fuzz]
 command = "cargo"
 args = ["test", "--workspace", "--no-default-features", "--features=rust-fuzz", "rust_fuzz", "--", "--skip", "generated"]
 

--- a/build.rs
+++ b/build.rs
@@ -42,7 +42,7 @@ fn prepare(readme: &str) -> String {
             if !feature_section && line.starts_with("## Features") {
                 feature_section = true;
             } else if feature_section && line.starts_with("### ") {
-                feature = line.replace("### ", "").replace("`", "");
+                feature = line.replace("### ", "").replace('`', "");
             }
             cleaned.push_str(line);
         }


### PR DESCRIPTION
By default, these tests were not running. This allows them to run using the `test-misc` task.