### PR TITLE
Update diesel to 2.0.0.rc-0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ arrayvec = { default-features = false, version = "0.7" }
 borsh = { default-features = false, optional = true, version = "0.9.3" }
 byteorder = { default-features = false, optional = true, version = "1.3" }
 bytes = { default-features = false, optional = true, version = "1.0" }
-diesel = { default-features = false, optional = true, version = "1.4" }
+diesel = { default-features = false, optional = true, version = "2.0.0-rc.0" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.1" }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -14,6 +14,10 @@ use core::{
     str::FromStr,
 };
 #[cfg(feature = "diesel")]
+use diesel::deserialize::FromSqlRow;
+#[cfg(feature = "diesel")]
+use diesel::expression::AsExpression;
+#[cfg(feature = "diesel")]
 use diesel::sql_types::Numeric;
 #[allow(unused_imports)] // It's not actually dead code below, but the compiler thinks it is.
 #[cfg(not(feature = "std"))]
@@ -95,7 +99,7 @@ pub struct UnpackedDecimal {
 /// where m is an integer such that -2<sup>96</sup> < m < 2<sup>96</sup>, and e is an integer
 /// between 0 and 28 inclusive.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
+#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), diesel(sql_type = Numeric))]
 #[cfg_attr(feature = "c-repr", repr(C))]
 #[cfg_attr(
     feature = "borsh",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,10 +60,6 @@ pub mod prelude {
     pub use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
 }
 
-#[cfg(feature = "diesel")]
-#[macro_use]
-extern crate diesel;
-
 /// Shortcut for `core::result::Result<T, rust_decimal::Error>`. Useful to distinguish
 /// between `rust_decimal` and `std` types.
 pub type Result<T> = core::result::Result<T, Error>;

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -1,11 +1,11 @@
 use core::{convert::TryInto, fmt};
 use std::error;
 
-use crate::{
-    Decimal,
-    ops::array::{div_by_u32, is_all_zero, mul_by_u32},
-};
 use crate::constants::MAX_PRECISION_U32;
+use crate::{
+    ops::array::{div_by_u32, is_all_zero, mul_by_u32},
+    Decimal,
+};
 
 #[derive(Debug, Clone)]
 pub struct InvalidDecimal {
@@ -32,7 +32,7 @@ struct PostgresDecimal<D> {
 }
 
 impl Decimal {
-    fn from_postgres<D: ExactSizeIterator<Item=u16>>(
+    fn from_postgres<D: ExactSizeIterator<Item = u16>>(
         PostgresDecimal {
             neg,
             scale,
@@ -467,7 +467,7 @@ mod diesel_postgres {
 mod _postgres {
     use std::io::Cursor;
 
-    use ::postgres::types::{FromSql, IsNull, to_sql_checked, ToSql, Type};
+    use ::postgres::types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
     use byteorder::{BigEndian, ReadBytesExt};
     use bytes::{BufMut, BytesMut};
 
@@ -531,7 +531,7 @@ mod _postgres {
             let mut raw = Cursor::new(raw);
             let num_groups = raw.read_u16::<BigEndian>()?;
             let weight = raw.read_i16::<BigEndian>()?; // 10000^weight
-            // Sign: 0x0000 = positive, 0x4000 = negative, 0xC000 = NaN
+                                                       // Sign: 0x0000 = positive, 0x4000 = negative, 0xC000 = NaN
             let sign = raw.read_u16::<BigEndian>()?;
             // Number of digits (in base 10) to print after decimal separator
             let scale = raw.read_u16::<BigEndian>()?;


### PR DESCRIPTION
Hi, 

I open this as draft, maybe this compatibility could be a different feature to avoid breaking changes to downstram projects and released after `diesel` 2.0 release, in the mean time a branch could be useful to others experimenting upgrading `diesel`.