### PR TITLE
Remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,16 +36,16 @@ serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
 
 [dev-dependencies]
-bincode = "1.3"
-bytes = "1.0"
+bincode = { default-features = false, version = "1.0" }
+bytes = { default-features = false, version = "1.0" }
 criterion = { default-features = false, version = "0.3" }
 csv = "1"
-futures = "0.3"
+futures = { default-features = false, version = "0.3" }
 rust_decimal_macros = { path = "macros" } # This should be ok since it's just for tests
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"
-tokio = { features = ["rt-multi-thread", "test-util", "macros"], version = "1.0" }
-version-sync = "0.9"
+tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.0" }
+version-sync = { default-features = false, features = ["html_root_url_updated", "markdown_deps_updated"], version = "0.9" }
 
 [features]
 c-repr = [] # Force Decimal to be repr(C)


### PR DESCRIPTION
Reduces network usage and decreases compilation times for development environments

`cargo test --all-features` went down from 330 to 324.