### PR TITLE
Add `rand` support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,12 @@ jobs:
           command: make
           args: test-macros
 
+      - name: Run `rand` tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: test-rand
+
   check_style:
     name: Check file formatting and style
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ bytes = { default-features = false, optional = true, version = "1.0" }
 diesel = { default-features = false, optional = true, version = "1.4" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
+rand = { default-features = false, optional = true, version = "0.8" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.1" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
@@ -41,6 +42,7 @@ bytes = { default-features = false, version = "1.0" }
 criterion = { default-features = false, version = "0.3" }
 csv = "1"
 futures = { default-features = false, version = "0.3" }
+rand = { default-features = false, features = ["getrandom"], version = "0.8" }
 rust_decimal_macros = { path = "macros" } # This should be ok since it's just for tests
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -251,3 +251,7 @@ args = ["test", "--workspace", "--tests", "--features=serde-with-str", "serde", 
 command = "cargo"
 args = ["test", "--workspace", "--features=borsh"]
 
+[tasks.test-rand]
+command = "cargo"
+args = ["test", "--workspace", "--features=rand"]
+

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Please note that `ln` and `log10` will panic on invalid input with `checked_ln` 
 to curb against this. When the `maths` feature was first developed the library would return `0` on invalid input. To re-enable this
 non-panicking behavior, please use the feature: `maths-nopanic`.
 
+### `rand`
+
+Implements `rand::distributions::Distribution<Decimal>` to allow the creation of random instances.
+
 ### `rocket-traits`
 
 Enable support for Rocket forms by implementing the `FromFormField` trait.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod constants;
 mod decimal;
 mod error;
 mod ops;
+mod rand;
 mod str;
 
 // We purposely place this here for documentation ordering

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -1,0 +1,31 @@
+#![cfg(feature = "rand")]
+
+use crate::Decimal;
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
+
+impl Distribution<Decimal> for Standard {
+    fn sample<R>(&self, rng: &mut R) -> Decimal
+    where
+        R: Rng + ?Sized,
+    {
+        Decimal::from_parts(
+            rng.next_u32(),
+            rng.next_u32(),
+            rng.next_u32(),
+            rng.gen(),
+            rng.next_u32(),
+        )
+    }
+}
+
+#[test]
+fn has_random_decimal_instances() {
+    let mut rng = rand::rngs::OsRng;
+    let random: [Decimal; 32] = rng.gen();
+    assert!(random.windows(2).any(|slice| {
+        slice[0] != slice[1]
+    }));
+}

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -25,7 +25,5 @@ impl Distribution<Decimal> for Standard {
 fn has_random_decimal_instances() {
     let mut rng = rand::rngs::OsRng;
     let random: [Decimal; 32] = rng.gen();
-    assert!(random.windows(2).any(|slice| {
-        slice[0] != slice[1]
-    }));
+    assert!(random.windows(2).any(|slice| { slice[0] != slice[1] }));
 }


### PR DESCRIPTION
Fix https://github.com/paupino/rust-decimal/issues/489 (Don't know why the issue was closed)

Through a feature called `rand` that is disabled by default