### PR TITLE
feat: Add `rng.gen_range` support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ non-panicking behavior, please use the feature: `maths-nopanic`.
 
 Implements `rand::distributions::Distribution<Decimal>` to allow the creation of random instances.
 
+Note: When using `rand::Rng` trait to generate a decimal between a range of two other decimals, the scale of the randomly-generated
+decimal will be the same as the scale of the input decimals (or, if the inputs have different scales, the higher of the two).
+
 ### `rkyv`
 Enables [rkyv](https://github.com/rkyv/rkyv) serialization for `Decimal`.
 Supports rkyv's safe API when the `rkyv-safe` feature is enabled as well.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ mod constants;
 mod decimal;
 mod error;
 mod ops;
-mod rand;
 mod str;
 
 // We purposely place this here for documentation ordering
@@ -25,6 +24,8 @@ mod mysql;
     feature = "db-diesel-postgres",
 ))]
 mod postgres;
+#[cfg(feature = "rand")]
+mod rand;
 #[cfg(feature = "rocket-traits")]
 mod rocket;
 #[cfg(all(

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -35,6 +35,22 @@ pub struct DecimalSampler {
 impl UniformSampler for DecimalSampler {
     type X = Decimal;
 
+    /// Creates a new sampler that will yield random decimal objects between `low` and `high`.
+    ///
+    /// The sampler will always provide decimals at the same scale as the inputs; if the inputs
+    /// have different scales, the higher scale is used.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use rand::Rng;
+    /// # use rust_decimal_macros::dec;
+    /// let mut rng = rand::rngs::OsRng;
+    /// let random = rng.gen_range(dec!(1.00)..dec!(2.00));
+    /// assert!(random >= dec!(1.00));
+    /// assert!(random < dec!(2.00));
+    /// assert_eq!(random.scale(), 2);
+    /// ```
     #[inline]
     fn new<B1, B2>(low: B1, high: B2) -> Self
     where
@@ -46,6 +62,22 @@ impl UniformSampler for DecimalSampler {
         UniformSampler::new_inclusive(low, high)
     }
 
+    /// Creates a new sampler that will yield random decimal objects between `low` and `high`.
+    ///
+    /// The sampler will always provide decimals at the same scale as the inputs; if the inputs
+    /// have different scales, the higher scale is used.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use rand::Rng;
+    /// # use rust_decimal_macros::dec;
+    /// let mut rng = rand::rngs::OsRng;
+    /// let random = rng.gen_range(dec!(1.00)..=dec!(2.00));
+    /// assert!(random >= dec!(1.00));
+    /// assert!(random <= dec!(2.00));
+    /// assert_eq!(random.scale(), 2);
+    /// ```
     #[inline]
     fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
     where


### PR DESCRIPTION
It appears that the previous work done in #517 only added partial `rand` support. In particular, it added support for `rng.gen()` but not `rng.gen_range()`. The latter lets you provide a low and high value and get a random number in between them:

```rs
let d = rng.gen_range(dec!(1.00)..=dec!(3.00));
assert!(d <= dec!(3.00));
assert!(d >= dec!(1.00));
```

This PR adds such support. It approaches the problem by taking the low and high values, rescaling them to match (with the higher of the two scales) if necessary, and then farming out the actual randomness by shipping off the mantissa values to `rand::distributions::uniform::UniformInt<i128>`. The `UniformInt` struct then returns the random mantissa, which is re-decimalized and returned.

Scale is relevant here, the example above is distinct from `rng.gen_range(dec!(1.0)..=dec!(3.0)`, because the original example has 201 valid values (1.00, 1.01, 1.02, etc.) whereas this later one has only three potential values (1.0, 2.0, 3.0). 