### PR TITLE
DRAFT: constify ops

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 mod constants;
 mod decimal;
 mod error;
-mod ops;
+pub mod ops;
 mod str;
 
 // We purposely place this here for documentation ordering
@@ -60,6 +60,7 @@ pub mod prelude {
     pub use crate::{Decimal, RoundingStrategy};
     pub use core::str::FromStr;
     pub use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
+    pub use crate::ops;
 }
 
 #[cfg(feature = "diesel")]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -25,7 +25,7 @@ mod rem;
 #[cfg(not(feature = "legacy-ops"))]
 pub(crate) use add::{add_impl, sub_impl};
 #[cfg(not(feature = "legacy-ops"))]
-pub(crate) use cmp::cmp_impl;
+pub use cmp::cmp_impl;
 #[cfg(not(feature = "legacy-ops"))]
 pub(crate) use div::div_impl;
 #[cfg(not(feature = "legacy-ops"))]


### PR DESCRIPTION
This PR (is intended to) make the fns in `rust_decimal::ops` const. Additionally, since `impl const Ord` [etc] are not stable yet, for these const fns to be useful, we need to actually export them.  (And eventually, once `impl const Trait` is stabilised, deprecate and unexport them.)

I've just done `cmp` so far, as a template for what will need to be done. Is this approach one that would be reasonable in `rust_decimal`?

TODO: 
* [x] `ops::cmp_impl`
* [ ] `ops::add_impl`
* [ ] `ops::sub_impl`
* [ ] `ops::mul_impl`
* [ ] `ops::div_impl`
* [ ] `ops::rem_impl`