### PR TITLE
Raising an error upon failure to deserialize overflowing number

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -833,7 +833,7 @@ mod test {
         pub struct OverflowExample {
             value: Decimal,
         }
-        // Going a fraction about the MAX number expecting it to fail but not panic.
+        // Going a fraction above the MAX number expecting it to fail, but not panic.
         let res: Result<Decimal, _> = Decimal::from_str(format!("{}.999999", Decimal::MAX).as_str());
         // Avoiding `#[should_panic]` to ensure we're returning an error.
         if res.is_ok() {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -826,4 +826,18 @@ mod test {
         let deserialized: StringExample = serde_json::from_str(r#"{"value":null}"#).unwrap();
         assert_eq!(deserialized.value, original.value);
     }
+
+    #[test]
+    fn with_overflow() {
+        #[derive(Serialize, Deserialize)]
+        pub struct OverflowExample {
+            value: Decimal,
+        }
+        // Going a fraction about the MAX number expecting it to fail but not panic.
+        let res: Result<Decimal, _> = Decimal::from_str(format!("{}.999999", Decimal::MAX).as_str());
+        // Avoiding `#[should_panic]` to ensure we're returning an error.
+        if res.is_ok() {
+            panic!("Expected to fail deserialization with overflow");
+        }
+    }
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -381,7 +381,10 @@ fn tail_no_has() -> Result<Decimal, crate::Error> {
 
 #[inline]
 fn handle_data<const NEG: bool, const HAS: bool>(data: u128, scale: u8) -> Result<Decimal, crate::Error> {
-    debug_assert_eq!(data >> 96, 0);
+    // Raising an error on malformed data, letting the client decide when to panic.
+    if data >> 96 != 0 {
+        return Err(Error::from("Invalid decimal: data >> 96 != 0"));
+    }
     if !HAS {
         tail_no_has()
     } else {


### PR DESCRIPTION
I found this panic scenario with the Decimal::serde deserializer when fuzz testing.