### PR TITLE
Diesel 2 feature support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,11 +151,11 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Run clippy
+      - name: Run clippy (default features)
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-features
+          args: --workspace
 
   fuzz:
     name: Fuzz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,11 @@ jobs:
 
       - uses: davidB/rust-cargo-make@v1
 
-      - name: Build rust-decimal
+      - name: Build default rust-decimal
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --all-features
+          args: --workspace
 
       - name: Run no_std tests
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ borsh = { default-features = false, optional = true, version = "0.9.3" }
 bytecheck = { default-features= false, optional = true, version = "0.6" }
 byteorder = { default-features = false, optional = true, version = "1.3" }
 bytes = { default-features = false, optional = true, version = "1.0" }
-diesel = { default-features = false, optional = true, version = "1.4" }
+diesel1 = { default-features = false, optional = true, package = "diesel", version = "1.4" }
+diesel2 = { default-features = false, optional = true, package = "diesel", version = "2.0.0-rc.1" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
 rand = { default-features = false, optional = true, version = "0.8" }
@@ -53,8 +54,12 @@ version-sync = { default-features = false, features = ["html_root_url_updated", 
 
 [features]
 c-repr = [] # Force Decimal to be repr(C)
-db-diesel-mysql = ["diesel/mysql", "std"]
-db-diesel-postgres = ["diesel/postgres", "std"]
+db-diesel-mysql = ["db-diesel1-mysql"]
+db-diesel-postgres = ["db-diesel1-postgres"]
+db-diesel1-mysql = ["diesel1/mysql", "std"]
+db-diesel1-postgres = ["diesel1/postgres", "std"]
+db-diesel2-mysql = ["diesel2/mysql", "std"]
+db-diesel2-postgres = ["diesel2/postgres", "std"]
 db-postgres = ["byteorder", "bytes", "postgres", "std"]
 db-tokio-postgres = ["byteorder", "bytes", "postgres", "std", "tokio-postgres"]
 default = ["serde", "std"]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -210,7 +210,8 @@ args = ["test", "--workspace", "--tests", "--features=db-diesel2-mysql", "mysql"
 dependencies = [
     "test-db-postgres",
     "test-db-tokio-postgres",
-    "test-db-diesel1-postgres"
+    "test-db-diesel1-postgres",
+    "test-db-diesel2-postgres"
 ]
 
 [tasks.test-db-postgres]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -184,26 +184,33 @@ dependencies = [
 command = "cargo"
 args = ["test", "--workspace", "--no-default-features", "--features=rust-fuzz", "rust_fuzz", "--", "--skip", "generated"]
 
-[tasks.test-db-diesel-all]
+[tasks.test-db-diesel]
 dependencies = [
-    "test-db-diesel-mysql",
-    "test-db-diesel-postgres",
+    "test-db-diesel1-mysql",
+    "test-db-diesel1-postgres",
+    "test-db-diesel2-mysql",
+    "test-db-diesel2-postgres",
 ]
 
 [tasks.test-db-mysql-all]
 dependencies = [
-    "test-db-diesel-mysql"
+    "test-db-diesel1-mysql",
+    "test-db-diesel2-mysql",
 ]
 
-[tasks.test-db-diesel-mysql]
+[tasks.test-db-diesel1-mysql]
 command = "cargo"
-args = ["test", "--workspace", "--tests", "--features=db-diesel-mysql", "mysql", "--", "--skip", "generated"]
+args = ["test", "--workspace", "--tests", "--features=db-diesel1-mysql", "mysql", "--", "--skip", "generated"]
+
+[tasks.test-db-diesel2-mysql]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=db-diesel2-mysql", "mysql", "--", "--skip", "generated"]
 
 [tasks.test-db-postgres-all]
 dependencies = [
     "test-db-postgres",
     "test-db-tokio-postgres",
-    "test-db-diesel-postgres"
+    "test-db-diesel1-postgres"
 ]
 
 [tasks.test-db-postgres]
@@ -214,9 +221,13 @@ args = ["test", "--workspace", "--tests", "--features=db-postgres", "postgres", 
 command = "cargo"
 args = ["test", "--workspace", "--tests", "--features=db-tokio-postgres", "postgres", "--", "--skip", "generated"]
 
-[tasks.test-db-diesel-postgres]
+[tasks.test-db-diesel1-postgres]
 command = "cargo"
-args = ["test", "--workspace", "--tests", "--features=db-diesel-postgres", "postgres", "--", "--skip", "generated"]
+args = ["test", "--workspace", "--tests", "--features=db-diesel1-postgres", "postgres", "--", "--skip", "generated"]
+
+[tasks.test-db-diesel2-postgres]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=db-diesel2-postgres", "postgres", "--", "--skip", "generated"]
 
 [tasks.test-rocket-traits]
 command = "cargo"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ assert_eq!(total.to_string(), "27.26");
 * [serde-with-arbitrary-precision](#serde-with-arbitrary-precision)
 
 ### `borsh`
+
 Enables [Borsh](https://borsh.io/) serialization for `Decimal`.
 
 ### `c-repr`

--- a/README.md
+++ b/README.md
@@ -118,11 +118,13 @@ Enables the tokio postgres module allowing for async communication with PostgreS
 
 ### `db-diesel-postgres`
 
-Enable `diesel` PostgreSQL support.
+Enable `diesel` PostgreSQL support. By default, this enables version `1.4` of `diesel`. If you wish to use the `diesel`
+release candidates then you can do so by using `db-diesel2-postgres`.
 
 ### `db-diesel-mysql`
 
-Enable `diesel` MySQL support.
+Enable `diesel` MySQL support. By default, this enables version `1.4` of `diesel`. If you wish to use the `diesel`
+release candidates then you can do so by using `db-diesel2-mysql`.
 
 ### `legacy-ops`
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -15,8 +15,15 @@ use core::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
     str::FromStr,
 };
-#[cfg(feature = "diesel")]
+
+// Diesel configuration
+#[cfg(feature = "diesel2")]
+use diesel::deserialize::FromSqlRow;
+#[cfg(feature = "diesel2")]
+use diesel::expression::AsExpression;
+#[cfg(any(feature = "diesel1", feature = "diesel2"))]
 use diesel::sql_types::Numeric;
+
 #[allow(unused_imports)] // It's not actually dead code below, but the compiler thinks it is.
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
@@ -99,7 +106,8 @@ pub struct UnpackedDecimal {
 /// where m is an integer such that -2<sup>96</sup> < m < 2<sup>96</sup>, and e is an integer
 /// between 0 and 28 inclusive.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
+#[cfg_attr(feature = "diesel1", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
+#[cfg_attr(feature = "diesel2", derive(FromSqlRow, AsExpression), diesel(sql_type = Numeric))]
 #[cfg_attr(feature = "c-repr", repr(C))]
 #[cfg_attr(
     feature = "borsh",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,12 +16,13 @@ mod arithmetic_impls;
 mod fuzz;
 #[cfg(feature = "maths")]
 mod maths;
-#[cfg(feature = "db-diesel-mysql")]
+#[cfg(any(feature = "db-diesel1-mysql", feature = "db-diesel2-mysql"))]
 mod mysql;
 #[cfg(any(
     feature = "db-tokio-postgres",
     feature = "db-postgres",
-    feature = "db-diesel-postgres"
+    feature = "db-diesel1-postgres",
+    feature = "db-diesel2-postgres",
 ))]
 mod postgres;
 #[cfg(feature = "rand")]
@@ -62,9 +63,15 @@ pub mod prelude {
     pub use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
 }
 
-#[cfg(feature = "diesel")]
+#[cfg(all(feature = "diesel1", feature = "diesel2"))]
+compile_error!("Only one diesel version can be compiled. Please select either diesel1 or diesel2.");
+
+#[cfg(feature = "diesel1")]
 #[macro_use]
-extern crate diesel;
+extern crate diesel1 as diesel;
+
+#[cfg(feature = "diesel2")]
+extern crate diesel2 as diesel;
 
 /// Shortcut for `core::result::Result<T, rust_decimal::Error>`. Useful to distinguish
 /// between `rust_decimal` and `std` types.

--- a/src/postgres.rs
+++ b/src/postgres.rs
@@ -1,7 +1,7 @@
 // Shared
 mod common;
 
-#[cfg(feature = "db-diesel-postgres")]
+#[cfg(any(feature = "db-diesel1-postgres", feature = "db-diesel2-postgres"))]
 mod diesel;
 
 #[cfg(any(feature = "db-postgres", feature = "db-tokio-postgres"))]


### PR DESCRIPTION
This enables `diesel 2.0.0-rc.1` support via two new feature flags: `db-diesel2-mysql` and `db-diesel2-postgres`. In fact, to make things easier `diesel` features are now explicit (i.e. `db-diesel1-*`) with a backwards compatible feature flag pointing to version `1.4`.

Another notable change is that because of uncertainty building both `diesel1` and `diesel2` at the same time, I explicitly include a compiler error if both features are enabled. 

Subsequently, the build system needed to relax during the first build step. It built using `--all-features` however due to complexities with Serde configuration etc it was admittedly a little pointless. Sadly though, I can't use `--all-features` on `clippy` anymore - though as a future change I made move this to the makefile and process feature by feature. It'd be nice if `cargo` allowed you to _exclude_ features as that way we could avoid conflicting features. 

Anyway, this closes #531 and replaces #512 (though thank you for the quick and easy updates I could apply!)