### PR TITLE
Fixes feature compilation for docs.rs by favoring diesel2 if feature specified

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,11 @@ jobs:
 
       - uses: davidB/rust-cargo-make@v1
 
-      - name: Build default rust-decimal
+      - name: Build rust-decimal
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace
+          args: --workspace --all-features # Important to keep this to ensure docs.rs passes
 
       - name: Run no_std tests
         uses: actions-rs/cargo@v1
@@ -151,11 +151,11 @@ jobs:
           command: fmt
           args: --all -- --check
 
-      - name: Run clippy (default features)
+      - name: Run clippy
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace
+          args: --workspace --all-features
 
   fuzz:
     name: Fuzz

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -106,7 +106,11 @@ pub struct UnpackedDecimal {
 /// where m is an integer such that -2<sup>96</sup> < m < 2<sup>96</sup>, and e is an integer
 /// between 0 and 28 inclusive.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "diesel1", derive(FromSqlRow, AsExpression), sql_type = "Numeric")]
+#[cfg_attr(
+    all(feature = "diesel1", not(feature = "diesel2")),
+    derive(FromSqlRow, AsExpression),
+    sql_type = "Numeric"
+)]
 #[cfg_attr(feature = "diesel2", derive(FromSqlRow, AsExpression), diesel(sql_type = Numeric))]
 #[cfg_attr(feature = "c-repr", repr(C))]
 #[cfg_attr(

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,11 +5,21 @@ use core::fmt;
 /// Error type for the library.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
+    /// A generic error from Rust Decimal with the `String` containing more information as to what
+    /// went wrong.
+    ///
+    /// This is a legacy/deprecated error type retained for backwards compatibility.  
     ErrorString(String),
+    /// The value provided exceeds `Decimal::MAX`.
     ExceedsMaximumPossibleValue,
+    /// The value provided is less than `Decimal::MIN`.
     LessThanMinimumPossibleValue,
+    /// An underflow is when there are more fractional digits than can be represented within `Decimal`.
     Underflow,
+    /// The scale provided exceeds the maximum scale that `Decimal` can represent.
     ScaleExceedsMaximumPrecision(u32),
+    /// Represents a failure to convert to/from `Decimal` to the specified type. This is typically
+    /// due to type constraints (e.g. `Decimal::MAX` cannot be converted into `i32`).
     ConversionTo(String),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,7 @@ pub mod prelude {
     pub use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
 }
 
-#[cfg(all(feature = "diesel1", feature = "diesel2"))]
-compile_error!("Only one diesel version can be compiled. Please select either diesel1 or diesel2.");
-
-#[cfg(feature = "diesel1")]
+#[cfg(all(feature = "diesel1", not(feature = "diesel2")))]
 #[macro_use]
 extern crate diesel1 as diesel;
 

--- a/src/mysql.rs
+++ b/src/mysql.rs
@@ -8,7 +8,7 @@ use diesel::{
 use std::io::Write;
 use std::str::FromStr;
 
-#[cfg(feature = "diesel1")]
+#[cfg(all(feature = "diesel1", not(feature = "diesel2")))]
 impl ToSql<Numeric, Mysql> for Decimal {
     fn to_sql<W: Write>(&self, out: &mut Output<W, Mysql>) -> serialize::Result {
         write!(out, "{}", *self).map(|_| IsNull::No).map_err(|e| e.into())
@@ -22,7 +22,7 @@ impl ToSql<Numeric, Mysql> for Decimal {
     }
 }
 
-#[cfg(feature = "diesel1")]
+#[cfg(all(feature = "diesel1", not(feature = "diesel2")))]
 impl FromSql<Numeric, Mysql> for Decimal {
     fn from_sql(numeric: Option<&[u8]>) -> deserialize::Result<Self> {
         // From what I can ascertain, MySQL simply reads from a string format for the Decimal type.
@@ -95,7 +95,7 @@ mod tests {
         "mysql://root@127.0.0.1/mysql".to_string()
     }
 
-    #[cfg(feature = "diesel1")]
+    #[cfg(all(feature = "diesel1", not(feature = "diesel2")))]
     mod diesel1 {
         use super::*;
 

--- a/src/postgres/diesel.rs
+++ b/src/postgres/diesel.rs
@@ -67,7 +67,7 @@ impl From<Decimal> for PgNumeric {
     }
 }
 
-#[cfg(feature = "diesel1")]
+#[cfg(all(feature = "diesel1", not(feature = "diesel2")))]
 impl ToSql<Numeric, Pg> for Decimal {
     fn to_sql<W: std::io::Write>(&self, out: &mut Output<W, Pg>) -> serialize::Result {
         let numeric = PgNumeric::from(self);
@@ -83,7 +83,7 @@ impl ToSql<Numeric, Pg> for Decimal {
     }
 }
 
-#[cfg(feature = "diesel1")]
+#[cfg(all(feature = "diesel1", not(feature = "diesel2")))]
 impl FromSql<Numeric, Pg> for Decimal {
     fn from_sql(numeric: Option<&[u8]>) -> deserialize::Result<Self> {
         PgNumeric::from_sql(numeric)?.try_into()


### PR DESCRIPTION
This removes the mutually exclusive pattern for `diesel1` and `diesel2` due to it breaking docs.rs downstream. Consequently, if both features are enabled then the latter will be favored.

Closes #535 