### PR TITLE
add rkyv Clone/Copy derivations

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -121,7 +121,7 @@ pub struct UnpackedDecimal {
     feature = "rkyv",
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
-    archive_attr(derive(Debug))
+    archive_attr(derive(Clone, Copy, Debug))
 )]
 #[cfg_attr(feature = "rkyv-safe", archive_attr(derive(CheckBytes)))]
 pub struct Decimal {


### PR DESCRIPTION
Since Decimal is Clone/Copy, we might as well make its `rkyv::Archive`
representation also have these traits.