### PR TITLE
[v2] Replace error type with ones more like std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { default-features = false, features = ["macros", "rt-multi-thread", "te
 version-sync = { default-features = false, features = ["html_root_url_updated", "markdown_deps_updated"], version = "0.9" }
 
 [features]
+alloc = []
 c-repr = [] # Force Decimal to be repr(C)
 db-diesel-mysql = ["db-diesel1-mysql"]
 db-diesel-postgres = ["db-diesel1-postgres"]
@@ -76,7 +77,7 @@ serde-str = ["serde-with-str"]
 serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std"]
 serde-with-float = ["serde"]
 serde-with-str = ["serde"]
-std = []
+std = ["alloc"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [workspace]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2320,6 +2320,7 @@ impl ToPrimitive for Decimal {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Display for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let (rep, additional) = crate::str::to_str_internal(self, false, f.precision());
@@ -2332,18 +2333,21 @@ impl fmt::Display for Decimal {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::Debug for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         fmt::Display::fmt(self, f)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::LowerExp for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::str::fmt_scientific_notation(self, "e", f)
     }
 }
 
+#[cfg(feature = "alloc")]
 impl fmt::UpperExp for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::str::fmt_scientific_notation(self, "E", f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ mod serde;
 pub mod serde;
 
 pub use decimal::{Decimal, RoundingStrategy};
-pub use error::Error;
+pub use error::{ParseDecimalError, TryFromDecimalError, TryIntoDecimalError};
 #[cfg(feature = "maths")]
 pub use maths::MathematicalOps;
 
@@ -70,9 +70,9 @@ extern crate diesel1 as diesel;
 #[cfg(feature = "diesel2")]
 extern crate diesel2 as diesel;
 
-/// Shortcut for `core::result::Result<T, rust_decimal::Error>`. Useful to distinguish
-/// between `rust_decimal` and `std` types.
-pub type Result<T> = core::result::Result<T, Error>;
+// /// Shortcut for `core::result::Result<T, rust_decimal::Error>`. Useful to distinguish
+// /// between `rust_decimal` and `std` types.
+// pub type Result<T> = core::result::Result<T, Error>;
 
 // #[cfg(feature = "legacy-ops")]
 // compiler_error!("legacy-ops has been removed as 1.x");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/README-lib.md"))]
 #![forbid(unsafe_code)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod constants;

--- a/src/str.rs
+++ b/src/str.rs
@@ -7,6 +7,7 @@ use crate::{
 
 use arrayvec::{ArrayString, ArrayVec};
 
+#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 use core::fmt;
 
@@ -76,6 +77,7 @@ pub(crate) fn to_str_internal(
     (rep, additional)
 }
 
+#[cfg(feature = "alloc")]
 pub(crate) fn fmt_scientific_notation(
     value: &Decimal,
     exponent_symbol: &str,


### PR DESCRIPTION
A start towards #49, though I haven't audited panicking, just migrated the existing errors.

Notably, because the error type no longer holds `String`, the crate no longer has a hard requirement on alloc.