### PR TITLE
Bump Diesel 2 feature support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bytecheck = { default-features= false, optional = true, version = "0.6" }
 byteorder = { default-features = false, optional = true, version = "1.3" }
 bytes = { default-features = false, optional = true, version = "1.0" }
 diesel1 = { default-features = false, optional = true, package = "diesel", version = "1.4" }
-diesel2 = { default-features = false, optional = true, package = "diesel", version = "2.0.0-rc.1" }
+diesel2 = { default-features = false, optional = true, package = "diesel", version = "2.0" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
 rand = { default-features = false, optional = true, version = "0.8" }

--- a/README.md
+++ b/README.md
@@ -141,15 +141,15 @@ Enables the tokio postgres module allowing for async communication with PostgreS
 
 ### `db-diesel-postgres`
 
-Enable `diesel` PostgreSQL support. By default, this enables version `1.4` of `diesel`. If you wish to use the `diesel`
-release candidates then you can do so by using `db-diesel2-postgres`. Please note, the `db-diesel2-*` features are considered
-unstable and will be upgraded as and when new `diesel 2.x` features are released.
+Enable `diesel` PostgreSQL support. By default, this enables version `1.4` of `diesel`. If you wish to use the `2.0` 
+version of `diesel` then you can do so by using the feature `db-diesel2-postgres`. Please note, if both features are 
+enabled then version 2 will supersede version 1.
 
 ### `db-diesel-mysql`
 
-Enable `diesel` MySQL support. By default, this enables version `1.4` of `diesel`. If you wish to use the `diesel`
-release candidates then you can do so by using `db-diesel2-mysql`. Please note, the `db-diesel2-*` features are considered
-unstable and will be upgraded as and when new `diesel 2.x` features are released.
+Enable `diesel` MySQL support. By default, this enables version `1.4` of `diesel`. If you wish to use the `2.0` 
+version of `diesel` then you can do so by using the feature `db-diesel2-mysql`. Please note, if both features are
+enabled then version 2 will supersede version 1.
 
 ### `legacy-ops`
 


### PR DESCRIPTION
Diesel 2.0 is released so bumping `rc` support for major version support.