### PR TITLE
Add parity scale codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ build = "build.rs"
 all-features = true
 
 [dependencies]
+parity-scale-codec = {package = "parity-scale-codec", optional = true, version = "3.1.5"}
+parity-scale-codec-derive = {package = "parity-scale-codec-derive", optional = true, version = "3.1.3"}
 arbitrary = { default-features = false, optional = true, version = "1.0" }
 arrayvec = { default-features = false, version = "0.7" }
 borsh = { default-features = false, optional = true, version = "0.9.3" }
@@ -78,6 +80,7 @@ serde-with-float = ["serde"]
 serde-with-str = ["serde"]
 std = []
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
+scale-codec =  ["parity-scale-codec-derive","parity-scale-codec"]
 
 [workspace]
 members = [".", "./macros"]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -30,6 +30,8 @@ use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
+#[cfg(feature = "scale-codec")]
+use parity_scale_codec_derive::{Decode,Encode};
 
 /// The smallest value that can be represented by this decimal type.
 const MIN: Decimal = Decimal {
@@ -124,6 +126,10 @@ pub struct UnpackedDecimal {
     archive_attr(derive(Clone, Copy, Debug))
 )]
 #[cfg_attr(feature = "rkyv-safe", archive_attr(derive(CheckBytes)))]
+#[cfg_attr(
+feature = "scale-codec",
+derive(Decode, Encode),
+)]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale


### PR DESCRIPTION
PR adds support of `parity-scale-codec` for rust-decimal.


References
1. https://docs.substrate.io/reference/scale-codec/
2. https://github.com/paritytech/parity-scale-codec