### PR TITLE
Use the new feature resolver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,7 +192,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.56.0
+          toolchain: 1.60.0
           profile: minimal
           override: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ path = "benches/comparison.rs"
 
 [package]
 authors = ["Paul Mason <paul@form1.co.nz>"]
+build = "build.rs"
 categories = ["science","mathematics","data-structures"]
 description = "Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations."
 documentation = "https://docs.rs/rust_decimal/"
@@ -15,8 +16,8 @@ license = "MIT"
 name = "rust_decimal"
 readme = "./README.md"
 repository = "https://github.com/paupino/rust-decimal"
+rust-version = "1.60"
 version = "1.26.1"
-build = "build.rs"
 
 [package.metadata.docs.rs]
 all-features = true
@@ -24,11 +25,11 @@ all-features = true
 [dependencies]
 arbitrary = { default-features = false, optional = true, version = "1.0" }
 arrayvec = { default-features = false, version = "0.7" }
-borsh = { default-features = false, optional = true, version = "0.9.3" }
+borsh = { default-features = false, optional = true, version = "0.9" }
 bytecheck = { default-features= false, optional = true, version = "0.6" }
-byteorder = { default-features = false, optional = true, version = "1.3" }
+byteorder = { default-features = false, optional = true, version = "1.0" }
 bytes = { default-features = false, optional = true, version = "1.0" }
-diesel1 = { default-features = false, optional = true, package = "diesel", version = "1.4" }
+diesel1 = { default-features = false, optional = true, package = "diesel", version = "1.0" }
 diesel2 = { default-features = false, optional = true, package = "diesel", version = "2.0" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
@@ -66,7 +67,7 @@ default = ["serde", "std"]
 legacy-ops = []
 maths = []
 maths-nopanic = ["maths"]
-rkyv-safe = ["bytecheck", "rkyv", "rkyv/validation"]
+rkyv-safe = ["bytecheck", "rkyv/validation"]
 rocket-traits = ["rocket"]
 rust-fuzz = ["arbitrary"]
 serde-arbitrary-precision = ["serde-with-arbitrary-precision"]
@@ -76,7 +77,7 @@ serde-str = ["serde-with-str"]
 serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std"]
 serde-with-float = ["serde"]
 serde-with-str = ["serde"]
-std = []
+std = ["arrayvec/std", "borsh?/std", "bytecheck?/std", "byteorder?/std", "bytes?/std", "rand?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ Please refer to the [Build document](BUILD.md) for more information on building 
 
 ## Minimum Rust Compiler Version
 
-The current _minimum_ compiler version is [`1.56.0`](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1560-2021-10-21)
-which was released on `2021-10-21`.
+The current _minimum_ compiler version is [`1.60.0`](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1600-2022-04-07)
+which was released on `2022-04-07`.
 
 This library maintains support for rust compiler versions that are 4 minor versions away from the current stable rust compiler version.
 For example, if the current stable compiler version is `1.50.0` then we will guarantee support up to and including `1.46.0`.

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -4,9 +4,6 @@ use crate::constants::{
 };
 use crate::ops;
 use crate::Error;
-
-#[cfg(feature = "rkyv-safe")]
-use bytecheck::CheckBytes;
 use core::{
     cmp::{Ordering::Equal, *},
     fmt,
@@ -123,7 +120,7 @@ pub struct UnpackedDecimal {
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, Debug))
 )]
-#[cfg_attr(feature = "rkyv-safe", archive_attr(derive(CheckBytes)))]
+#[cfg_attr(feature = "rkyv-safe", archive_attr(derive(bytecheck::CheckBytes)))]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale


### PR DESCRIPTION
# Previous  behaviour

The usage of an optional feature always pulls the optional dependencies listed in the same feature even if these dependencies weren't explicitly required, which is generally undesired, surprising and slower.

```toml
[dependencies]
rgb = { default-features = false, optional = true, version = "0.8" }
serde = { default-features = false, optional = true, version = "1.0" }

[features]
# `with-serde` will always bring `serde` as well as `rgb`
with-serde = ["rgb/serde", "serde"]
```

# Current behaviour

With the new "weak dependency" feature, optional dependencies won't be automatically pulled effectively solving the above problem.

```toml
[dependencies]
rgb = { default-features = false, optional = true, version = "0.8" }
serde = { default-features = false, optional = true, version = "1.0" }

[features]
# `rgb` won't be included unless the `rgb` feature is required
with-serde = ["rgb?/serde", "serde"]
```

# Future behaviour

The "name-spaced dependency" feature enables the listing of optional features using the name of any optional dependency, so, instead of creating features with prefixes, suffices or funny names to avoid overlapping, it will be possible to group related stuff in intuitive names.

```toml
[dependencies]
rgb = { default-features = false, optional = true, version = "0.8" }
serde = { default-features = false, optional = true, version = "1.0" }

[features]
# `serde` can now be used as a feature with `dep:`
serde = ["rgb?/serde", "dep:serde"]
```
