### PR TITLE
Move `size_32` rkyv feature to test dependencies.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --workspace --all-features # Important to keep this to ensure docs.rs passes
+          args: --workspace --features rkyv/size_32 --all-features # Important to keep this to ensure docs.rs passes
 
       - name: Run no_std tests
         uses: actions-rs/cargo@v1
@@ -155,7 +155,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-features
+          args: --workspace --features rkyv/size_32 --all-features
 
   fuzz:
     name: Fuzz

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ diesel2 = { default-features = false, optional = true, package = "diesel", versi
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
 rand = { default-features = false, optional = true, version = "0.8" }
-rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7" }
+rkyv = { default-features = false, features = ["std"], optional = true, version = "0.7" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.1" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
@@ -52,6 +52,7 @@ serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"
 tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.0" }
 version-sync = { default-features = false, features = ["html_root_url_updated", "markdown_deps_updated"], version = "0.9" }
+rkyv = { default-features = false, features = ["size_32"], version = "0.7" }
 
 [features]
 c-repr = [] # Force Decimal to be repr(C)


### PR DESCRIPTION
rkyv requires users to specify one of its `size_*` features. However, they are mutually exclusive, so if a library like `rust-decimal` enables `size_32`, end users will not be able to use e.g. `size_64`.

This is a breaking change for existing `rust-decimal` users who use the `rkyv` feature, as they will now need to explicitly set a `size_*` feature on their `rkyv` dependency.