### PR TITLE
Implement `TryFrom<&str>` for `Decimal`

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1770,7 +1770,7 @@ impl_try_from_decimal!(u128, Decimal::to_u128, integer_docs!(true));
 // See https://github.com/rust-lang/rustfmt/issues/5062 for more information.
 #[rustfmt::skip]
 macro_rules! impl_try_from_primitive {
-    ($TFrom:ty, $conversion_fn:path) => {
+    ($TFrom:ty, $conversion_fn:path $(, $err:expr)?) => {
         #[doc = concat!(
             "Try to convert a `",
             stringify!($TFrom),
@@ -1781,14 +1781,15 @@ macro_rules! impl_try_from_primitive {
 
             #[inline]
             fn try_from(t: $TFrom) -> Result<Self, Error> {
-                $conversion_fn(t).ok_or_else(|| Error::ConversionTo("Decimal".into()))
+                $conversion_fn(t) $( .ok_or_else(|| $err) )?
             }
         }
     };
 }
 
-impl_try_from_primitive!(f32, Self::from_f32);
-impl_try_from_primitive!(f64, Self::from_f64);
+impl_try_from_primitive!(f32, Self::from_f32, Error::ConversionTo("Decimal".into()));
+impl_try_from_primitive!(f64, Self::from_f64, Error::ConversionTo("Decimal".into()));
+impl_try_from_primitive!(&str, core::str::FromStr::from_str);
 
 macro_rules! impl_from {
     ($T:ty, $from_ty:path) => {

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -2860,6 +2860,12 @@ fn it_converts_from_u128() {
 }
 
 #[test]
+fn it_converts_from_str() {
+    assert_eq!(Decimal::try_from("1").unwrap(), Decimal::ONE);
+    assert_eq!(Decimal::try_from("10").unwrap(), Decimal::TEN);
+}
+
+#[test]
 fn it_converts_from_f32() {
     use num_traits::FromPrimitive;
 


### PR DESCRIPTION
Has the same implementation of `FromStr for Decimal`. 

Advantageous because `TryFrom` is already included in the prelude meaning that no import is necessary.

```rust
use core::str::FromStr;
let _ = Decimal::from_str("1");
```

```rust
let _ = Decimal::try_from("1");
```