### PR TITLE
Explicit string (de)serialize for optional serde-with-str values

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -259,7 +259,7 @@ pub mod str_option {
     where
         D: serde::de::Deserializer<'de>,
     {
-        deserializer.deserialize_option(OptionDecimalVisitor)
+        deserializer.deserialize_option(OptionDecimalStrVisitor)
     }
 
     pub fn serialize<S>(value: &Option<Decimal>, serializer: S) -> Result<S::Ok, S::Error>
@@ -269,7 +269,7 @@ pub mod str_option {
         match *value {
             Some(ref decimal) => {
                 let decimal = crate::str::to_str_internal(decimal, true, None);
-                serializer.serialize_str(decimal.0.as_ref())
+                serializer.serialize_some(decimal.0.as_ref())
             }
             None => serializer.serialize_none(),
         }
@@ -401,6 +401,35 @@ impl<'de> serde::de::Visitor<'de> for OptionDecimalVisitor {
         D: serde::de::Deserializer<'de>,
     {
         <Decimal as serde::Deserialize>::deserialize(d).map(Some)
+    }
+}
+
+#[cfg(feature = "serde-with-str")]
+struct OptionDecimalStrVisitor;
+
+#[cfg(feature = "serde-with-str")]
+impl<'de> serde::de::Visitor<'de> for OptionDecimalStrVisitor {
+    type Value = Option<Decimal>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        println!("Here4");
+        formatter.write_str("a Decimal type representing a fixed-point number")
+    }
+
+    fn visit_none<E>(self) -> Result<Option<Decimal>, E>
+    where
+        E: serde::de::Error,
+    {
+        println!("Here2");
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, d: D) -> Result<Option<Decimal>, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        println!("Here3");
+        d.deserialize_str(DecimalVisitor).map(Some)
     }
 }
 
@@ -744,7 +773,7 @@ mod test {
         use bincode::{deserialize, serialize};
 
         #[derive(Serialize, Deserialize)]
-        pub struct BincodeExample {
+        struct BincodeExample {
             #[serde(with = "crate::serde::str")]
             value: Decimal,
         }
@@ -752,6 +781,7 @@ mod test {
         let data = [
             ("0", "0"),
             ("0.00", "0.00"),
+            ("1.234", "1.234"),
             ("3.14159", "3.14159"),
             ("-3.14159", "-3.14159"),
             ("1234567890123.4567890", "1234567890123.4567890"),
@@ -766,6 +796,31 @@ mod test {
             let decoded: BincodeExample = deserialize(&encoded[..]).unwrap();
             assert_eq!(expected, decoded.value);
         }
+    }
+
+    #[test]
+    #[cfg(feature = "serde-with-str")]
+    fn with_str_bincode_optional() {
+        use bincode::{deserialize, serialize};
+
+        #[derive(Serialize, Deserialize)]
+        struct BincodeExample {
+            #[serde(with = "crate::serde::str_option")]
+            value: Option<Decimal>,
+        }
+
+        // Some(value)
+        let value = Some(Decimal::new(1234, 3));
+        let input = BincodeExample { value };
+        let encoded = serialize(&input).unwrap();
+        let decoded: BincodeExample = deserialize(&encoded[..]).unwrap();
+        assert_eq!(value, decoded.value, "Some(value)");
+
+        // None
+        let input = BincodeExample { value: None };
+        let encoded = serialize(&input).unwrap();
+        let decoded: BincodeExample = deserialize(&encoded[..]).unwrap();
+        assert_eq!(None, decoded.value, "None");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #563 

This should resolve optional values not serializing/deserializing properly with bincode. This is a two part fix:

1. We explicitly `serialize_some` now to ensure that the `Some` enum is encoded properly
2. We use an explicit `Deserialize` visitor that will always use string deserialization rather than rely on a hint