### PR TITLE
Fixes rescale allowing zeros to scale greater than the maximum possible precision

### DIFF
--- a/src/postgres/driver.rs
+++ b/src/postgres/driver.rs
@@ -237,6 +237,20 @@ mod test {
     }
 
     #[test]
+    fn read_very_small_numeric_type() {
+        let mut client = match Client::connect(&get_postgres_url(), NoTls) {
+            Ok(x) => x,
+            Err(err) => panic!("{:#?}", err),
+        };
+        let result: Decimal = match client.query("SELECT 1e-130::NUMERIC(130, 0)", &[]) {
+            Ok(x) => x.iter().next().unwrap().get(0),
+            Err(err) => panic!("error - {:#?}", err),
+        };
+        // We compare this to zero since it is so small that it is effectively zero
+        assert_eq!(Decimal::ZERO, result);
+    }
+
+    #[test]
     fn read_numeric_type() {
         let mut client = match Client::connect(&get_postgres_url(), NoTls) {
             Ok(x) => x,


### PR DESCRIPTION
Fixes #564 

This fixes a problem whereby a very small number/zero could potentially be parsed with an invalid scale above the maximum precision. Since this is inferred in other parts of the code this could cause unexpected behavior (as seen in #564).