### PR TITLE
Introduce `trunc_with_scale`

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1050,6 +1050,21 @@ impl Decimal {
         }
     }
 
+    /// Returns a new `Decimal` with the fractional portion delimited by `scale`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use rust_decimal::Decimal;
+    /// #
+    /// let pi = Decimal::new(3141592, 6);
+    /// assert_eq!(pi.trunc_with_scale(2), Decimal::new(314, 2));
+    /// ```
+    #[must_use]
+    pub fn trunc_with_scale(&self, scale: u32) -> Decimal {
+        self.round_dp_with_strategy(scale, RoundingStrategy::ToZero)
+    }
+
     /// Returns a new `Decimal` representing the fractional portion of the number.
     ///
     /// # Example

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -2631,6 +2631,29 @@ fn it_can_trunc() {
 }
 
 #[test]
+fn it_can_trunc_with_scale() {
+    let cmp = Decimal::from_str("1.2345").unwrap();
+    assert_eq!(Decimal::from_str("1.23450").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("1.234500001").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("1.23451").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("1.23454").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("1.23455").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("1.23456").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("1.23459").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("1.234599999").unwrap().trunc_with_scale(4), cmp);
+
+    let cmp = Decimal::from_str("-1.2345").unwrap();
+    assert_eq!(Decimal::from_str("-1.23450").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("-1.234500001").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("-1.23451").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("-1.23454").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("-1.23455").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("-1.23456").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("-1.23459").unwrap().trunc_with_scale(4), cmp);
+    assert_eq!(Decimal::from_str("-1.234599999").unwrap().trunc_with_scale(4), cmp);
+}
+
+#[test]
 fn it_can_fract() {
     let tests = &[
         ("1.00000000000000000000", "0.00000000000000000000"),


### PR DESCRIPTION
Feel free to close this PR if such thing is not desired.

It took me quite some time to figure out how to truncate the fractional part to a certain scale so I thought that other people could also benefit from this method.
The internal implementation is shamelessly re-using `round_dp_with_strategy` but in the future a more efficient code can be elaborated.