### PR TITLE
Add `ndarray` support for arithmetic operations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ byteorder = { default-features = false, optional = true, version = "1.0" }
 bytes = { default-features = false, optional = true, version = "1.0" }
 diesel1 = { default-features = false, optional = true, package = "diesel", version = "1.0" }
 diesel2 = { default-features = false, optional = true, package = "diesel", version = "2.0" }
+ndarray = { default-features = false, optional = true, version = "0.15.6" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
 rand = { default-features = false, optional = true, version = "0.8" }
@@ -69,6 +70,7 @@ db-tokio-postgres = ["dep:byteorder", "dep:bytes", "dep:postgres", "std", "dep:t
 legacy-ops = []
 maths = []
 maths-nopanic = ["maths"]
+ndarray = ["dep:ndarray"]
 rand = ["dep:rand"]
 rkyv = ["dep:rkyv"]
 rkyv-safe = ["dep:bytecheck", "rkyv/validation"]

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ assert_eq!(total, dec!(27.26));
 * [c-repr](#c-repr)
 * [legacy-ops](#legacy-ops)
 * [maths](#maths)
+* [ndarray](#ndarray)
 * [rkyv](#rkyv)
 * [rocket-traits](#rocket-traits)
 * [rust-fuzz](#rust-fuzz)
@@ -167,6 +168,10 @@ Documentation detailing the additional functions can be found on the
 Please note that `ln` and `log10` will panic on invalid input with `checked_ln` and `checked_log10` the preferred functions
 to curb against this. When the `maths` feature was first developed the library would instead return `0` on invalid input. To re-enable this
 non-panicking behavior, please use the feature: `maths-nopanic`.
+
+### `ndarray`
+
+Enables arithmetic operations using [`ndarray`](https://github.com/rust-ndarray/ndarray) on arrays of `Decimal`.
 
 ### `rand`
 

--- a/make/tests/misc.toml
+++ b/make/tests/misc.toml
@@ -19,6 +19,10 @@ args = ["test", "--workspace", "--features=rocket-traits"]
 command = "cargo"
 args = ["test", "--workspace", "--features=borsh", "--", "--skip", "generated"]
 
+[tasks.test-ndarray]
+command = "cargo"
+args = ["test", "--workspace", "--features=ndarray", "--", "--skip", "generated"]
+
 [tasks.test-rkyv]
 command = "cargo"
 args = ["test", "--workspace", "--features=rkyv", "--features=rkyv-safe", "--", "--skip", "generated"]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -134,6 +134,9 @@ pub struct Decimal {
     mid: u32,
 }
 
+#[cfg(feature = "ndarray")]
+impl ndarray::ScalarOperand for Decimal {}
+
 /// `RoundingStrategy` represents the different rounding strategies that can be used by
 /// `round_dp_with_strategy`.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -153,6 +153,55 @@ fn it_can_serialize_deserialize_borsh() {
 }
 
 #[test]
+#[cfg(feature = "ndarray")]
+fn it_can_do_scalar_ops_in_ndarray() {
+    use ndarray::Array1;
+    use num_traits::FromPrimitive;
+
+    let array_a = Array1::from(vec![
+        Decimal::from_f32(1.0).unwrap(),
+        Decimal::from_f32(2.0).unwrap(),
+        Decimal::from_f32(3.0).unwrap(),
+    ]);
+
+    // Add
+    let output = array_a.clone() + Decimal::from_f32(5.0).unwrap();
+    let expectation = Array1::from(vec![
+        Decimal::from_f32(6.0).unwrap(),
+        Decimal::from_f32(7.0).unwrap(),
+        Decimal::from_f32(8.0).unwrap(),
+    ]);
+    assert_eq!(output, expectation);
+
+    // Sub
+    let output = array_a.clone() - Decimal::from_f32(5.0).unwrap();
+    let expectation = Array1::from(vec![
+        Decimal::from_f32(-4.0).unwrap(),
+        Decimal::from_f32(-3.0).unwrap(),
+        Decimal::from_f32(-2.0).unwrap(),
+    ]);
+    assert_eq!(output, expectation);
+
+    // Mul
+    let output = array_a.clone() * Decimal::from_f32(5.0).unwrap();
+    let expectation = Array1::from(vec![
+        Decimal::from_f32(5.0).unwrap(),
+        Decimal::from_f32(10.0).unwrap(),
+        Decimal::from_f32(15.0).unwrap(),
+    ]);
+    assert_eq!(output, expectation);
+
+    // Div
+    let output = array_a / Decimal::from_f32(5.0).unwrap();
+    let expectation = Array1::from(vec![
+        Decimal::from_f32(0.2).unwrap(),
+        Decimal::from_f32(0.4).unwrap(),
+        Decimal::from_f32(0.6).unwrap(),
+    ]);
+    assert_eq!(output, expectation);
+}
+
+#[test]
 #[cfg(feature = "rkyv")]
 fn it_can_serialize_deserialize_rkyv() {
     use rkyv::Deserialize;


### PR DESCRIPTION
> **NOTE:** This is a follow up PR after https://github.com/paupino/rust-decimal/pull/577. I messed up slightly on my forked repository and was working on master, which later made it difficult to keep the fork in sync with main repository. My bad on this! **I fixed the requested comments (added tests).**

# Problem

I am currently using [ndarray](https://github.com/rust-ndarray/ndarray) with `rust-decimal`, but some operations requires the underlying structure to implement `ScalarOperation` marker.

# This PR

Enable such implementation under `ndarray` feature.