### PR TITLE
Implement is_integer function

### DIFF
--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3617,6 +3617,23 @@ fn test_inv() {
     assert_eq!("0.01", Decimal::ONE_HUNDRED.inv().to_string());
 }
 
+#[test]
+fn test_is_integer() {
+    let tests = &[
+        ("0", true),
+        ("1", true),
+        ("79_228_162_514_264_337_593_543_950_335", true),
+        ("1.0", true),
+        ("1.1", false),
+        ("3.1415926535897932384626433833", false),
+        ("3.0000000000000000000000000000", true),
+    ];
+    for &(raw, integer) in tests {
+        let value = Decimal::from_str(raw).unwrap();
+        assert_eq!(value.is_integer(), integer, "value: {}", raw)
+    }
+}
+
 // Mathematical features
 #[cfg(feature = "maths")]
 mod maths {


### PR DESCRIPTION
This is a simple implementation of `is_integer` for `Decimal`. This is intended to return true when the decimal is an integer without a fraction. 

```rust
assert_eq!(dec!(5), dec!(5.00));
assert!(dec!(5).is_integer());
assert!(dec!(5.00).is_integer());
assert!(dec!(5.01).is_integer() == false);
```

Fixes #590 