### PR TITLE
Enables `Abomonation` serialization for `Decimal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ version = "1.29.1"
 all-features = true
 
 [dependencies]
+abomonation = { default-features = false, optional = true, version = "0.7.3" }
+abomonation_derive = { default-features = false, optional = true, version = "0.5.0" }
 arbitrary = { default-features = false, optional = true, version = "1.0" }
 arrayvec = { default-features = false, version = "0.7" }
 borsh = { default-features = false, optional = true, version = "0.10.0" }
@@ -58,6 +60,7 @@ version-sync = { default-features = false, features = ["html_root_url_updated", 
 [features]
 default = ["serde", "std"]
 
+abomonation = ["dep:abomonation", "dep:abomonation_derive"]
 borsh = ["dep:borsh", "std"]
 c-repr = [] # Force Decimal to be repr(C)
 db-diesel-mysql = ["db-diesel1-mysql"]

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ assert_eq!(total, dec!(27.26));
 
 **Behavior / Functionality**
 
+* [abomonation](#abomonation)
 * [borsh](#borsh)
 * [c-repr](#c-repr)
 * [legacy-ops](#legacy-ops)
@@ -122,6 +123,10 @@ assert_eq!(total, dec!(27.26));
 * [serde-with-float](#serde-with-float)
 * [serde-with-str](#serde-with-str)
 * [serde-with-arbitrary-precision](#serde-with-arbitrary-precision)
+
+### `abomonation`
+
+Enables [Abomonation](https://github.com/TimelyDataflow/abomonation) serialization for `Decimal`.
 
 ### `borsh`
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -13,6 +13,9 @@ use core::{
     str::FromStr,
 };
 
+#[cfg(feature = "abomonation")]
+use abomonation_derive::Abomonation;
+
 // Diesel configuration
 #[cfg(feature = "diesel2")]
 use diesel::deserialize::FromSqlRow;
@@ -103,6 +106,7 @@ pub struct UnpackedDecimal {
 /// where m is an integer such that -2<sup>96</sup> < m < 2<sup>96</sup>, and e is an integer
 /// between 0 and 28 inclusive.
 #[derive(Clone, Copy)]
+#[cfg_attr(feature = "abomonation", derive(Abomonation))]
 #[cfg_attr(
     all(feature = "diesel1", not(feature = "diesel2")),
     derive(FromSqlRow, AsExpression),


### PR DESCRIPTION
[abomonation](https://github.com/TimelyDataflow/abomonation) is a serialization library mainly used in [td/dd](https://github.com/TimelyDataflow), this PR make `Decimal` works with [td/dd](https://github.com/TimelyDataflow).