### PR TITLE
updated rkyv with reexported bytecheck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ all-features = true
 arbitrary = { default-features = false, optional = true, version = "1.0" }
 arrayvec = { default-features = false, version = "0.7" }
 borsh = { default-features = false, optional = true, version = "0.10.0" }
-bytecheck = { default-features= false, optional = true, version = "0.6" }
 byteorder = { default-features = false, optional = true, version = "1.0" }
 bytes = { default-features = false, optional = true, version = "1.0" }
 diesel1 = { default-features = false, optional = true, package = "diesel", version = "1.0" }
@@ -36,7 +35,7 @@ num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres = { default-features = false, optional = true, version = "0.19" }
 proptest = { default-features = false, optional = true, features = ["std"], version = "1.0" }
 rand = { default-features = false, optional = true, version = "0.8" }
-rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7" }
+rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.42" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.1" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
@@ -75,7 +74,7 @@ ndarray = ["dep:ndarray"]
 proptest = ["dep:proptest"]
 rand = ["dep:rand"]
 rkyv = ["dep:rkyv"]
-rkyv-safe = ["dep:bytecheck", "rkyv/validation"]
+rkyv-safe = ["rkyv/validation"]
 rocket-traits = ["dep:rocket"]
 rust-fuzz = ["dep:arbitrary"]
 serde = ["dep:serde"]
@@ -86,7 +85,7 @@ serde-str = ["serde-with-str"]
 serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std"]
 serde-with-float = ["serde"]
 serde-with-str = ["serde"]
-std = ["arrayvec/std", "borsh?/std", "bytecheck?/std", "byteorder?/std", "bytes?/std", "rand?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]
+std = ["arrayvec/std", "borsh?/std", "byteorder?/std", "bytes?/std", "rand?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [workspace]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -120,7 +120,7 @@ pub struct UnpackedDecimal {
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, Debug))
 )]
-#[cfg_attr(feature = "rkyv-safe", archive_attr(derive(bytecheck::CheckBytes)))]
+#[cfg_attr(feature = "rkyv-safe", archive(check_bytes))]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale


### PR DESCRIPTION
This upstream PR removes `bytcheck` as a direct dependency for `rkyv/validation`:
https://github.com/rkyv/rkyv/pull/344
Thus it allows downstream crates such as this one to maintain one version for both `rkyv` & `bytecheck`