### PR TITLE
Clippy/fix ruleset

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,5 +6,6 @@ rustflags = [
     "-Aclippy::inconsistent_digit_grouping",
     "-Aclippy::large_digit_groups",
     "-Aclippy::excessive_precision",
+    "-Aclippy::zero_prefixed_literal",
 ]
 

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+[target.'cfg(all())']
+rustflags = [
+    # BEGIN - Embark standard lints v0.4
+    # do not change or add/remove here, but one can add exceptions after this section
+    # for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+    "-Aclippy::inconsistent_digit_grouping",
+    "-Aclippy::large_digit_groups",
+    "-Aclippy::excessive_precision",
+]
+

--- a/build.rs
+++ b/build.rs
@@ -43,14 +43,14 @@ fn prepare(readme: &str) -> Result<String, Box<dyn std::error::Error>> {
             writeln!(cleaned, "```rust")?;
             writeln!(cleaned, "# use rust_decimal::Decimal;")?;
             writeln!(cleaned, "# use serde::{{Serialize, Deserialize}};")?;
-            write!(cleaned, "# #[cfg(features = \"{}\")]", feature)?;
+            write!(cleaned, "# #[cfg(features = \"{feature}\")]")?;
         } else {
             if !feature_section && line.starts_with("## Features") {
                 feature_section = true;
             } else if feature_section && line.starts_with("### ") {
                 feature = line.replace("### ", "").replace('`', "");
             }
-            write!(cleaned, "{}", line)?;
+            write!(cleaned, "{line}")?;
         }
         writeln!(cleaned)?;
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,12 +57,11 @@ impl fmt::Display for Error {
             Self::ScaleExceedsMaximumPrecision(ref scale) => {
                 write!(
                     f,
-                    "Scale exceeds the maximum precision allowed: {} > {}",
-                    scale, MAX_PRECISION_U32
+                    "Scale exceeds the maximum precision allowed: {scale} > {MAX_PRECISION_U32}"
                 )
             }
             Self::ConversionTo(ref type_name) => {
-                write!(f, "Error while converting to {}", type_name)
+                write!(f, "Error while converting to {type_name}")
             }
         }
     }

--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -358,8 +358,7 @@ mod test {
             assert_eq!(value, expected_value);
             assert_eq!(
                 value_scale, expected_scale,
-                "value: {}, requested scale: {}",
-                value_raw, new_scale
+                "value: {value_raw}, requested scale: {new_scale}"
             );
         }
     }

--- a/src/postgres/driver.rs
+++ b/src/postgres/driver.rs
@@ -213,7 +213,7 @@ mod test {
 
         // Test NULL
         let result: Option<Decimal> = match client.query("SELECT NULL::numeric", &[]) {
-            Ok(x) => x.iter().next().unwrap().get(0),
+            Ok(x) => x.first().unwrap().get(0),
             Err(err) => panic!("{:#?}", err),
         };
         assert_eq!(None, result);
@@ -229,9 +229,9 @@ mod test {
         let connection = connection.map(|e| e.unwrap());
         tokio::spawn(connection);
 
-        let statement = client.prepare(&"SELECT NULL::numeric").await.unwrap();
+        let statement = client.prepare("SELECT NULL::numeric").await.unwrap();
         let rows = client.query(&statement, &[]).await.unwrap();
-        let result: Option<Decimal> = rows.iter().next().unwrap().get(0);
+        let result: Option<Decimal> = rows.first().unwrap().get(0);
 
         assert_eq!(None, result);
     }
@@ -243,7 +243,7 @@ mod test {
             Err(err) => panic!("{:#?}", err),
         };
         let result: Decimal = match client.query("SELECT 1e-130::NUMERIC(130, 0)", &[]) {
-            Ok(x) => x.iter().next().unwrap().get(0),
+            Ok(x) => x.first().unwrap().get(0),
             Err(err) => panic!("error - {:#?}", err),
         };
         // We compare this to zero since it is so small that it is effectively zero
@@ -259,7 +259,7 @@ mod test {
         for &(precision, scale, sent, expected) in TEST_DECIMALS.iter() {
             let result: Decimal =
                 match client.query(&*format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale), &[]) {
-                    Ok(x) => x.iter().next().unwrap().get(0),
+                    Ok(x) => x.first().unwrap().get(0),
                     Err(err) => panic!("SELECT {}::NUMERIC({}, {}), error - {:#?}", sent, precision, scale, err),
                 };
             assert_eq!(
@@ -284,11 +284,11 @@ mod test {
         tokio::spawn(connection);
         for &(precision, scale, sent, expected) in TEST_DECIMALS.iter() {
             let statement = client
-                .prepare(&*format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale))
+                .prepare(&format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale))
                 .await
                 .unwrap();
             let rows = client.query(&statement, &[]).await.unwrap();
-            let result: Decimal = rows.iter().next().unwrap().get(0);
+            let result: Decimal = rows.first().unwrap().get(0);
 
             assert_eq!(expected, result.to_string(), "NUMERIC({}, {})", precision, scale);
         }
@@ -304,7 +304,7 @@ mod test {
             let number = Decimal::from_str(sent).unwrap();
             let result: Decimal =
                 match client.query(&*format!("SELECT $1::NUMERIC({}, {})", precision, scale), &[&number]) {
-                    Ok(x) => x.iter().next().unwrap().get(0),
+                    Ok(x) => x.first().unwrap().get(0),
                     Err(err) => panic!("{:#?}", err),
                 };
             assert_eq!(expected, result.to_string(), "NUMERIC({}, {})", precision, scale);
@@ -323,12 +323,12 @@ mod test {
 
         for &(precision, scale, sent, expected) in TEST_DECIMALS.iter() {
             let statement = client
-                .prepare(&*format!("SELECT $1::NUMERIC({}, {})", precision, scale))
+                .prepare(&format!("SELECT $1::NUMERIC({}, {})", precision, scale))
                 .await
                 .unwrap();
             let number = Decimal::from_str(sent).unwrap();
             let rows = client.query(&statement, &[&number]).await.unwrap();
-            let result: Decimal = rows.iter().next().unwrap().get(0);
+            let result: Decimal = rows.first().unwrap().get(0);
 
             assert_eq!(expected, result.to_string(), "NUMERIC({}, {})", precision, scale);
         }
@@ -367,7 +367,7 @@ mod test {
 
         for &(precision, scale, sent) in tests.iter() {
             let statement = client
-                .prepare(&*format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale))
+                .prepare(&format!("SELECT {}::NUMERIC({}, {})", sent, precision, scale))
                 .await
                 .unwrap();
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -555,8 +555,7 @@ mod test {
         ];
         for &(serialized, value) in data.iter() {
             let result = serde_json::from_str(serialized);
-            assert_eq!(
-                true,
+            assert!(
                 result.is_ok(),
                 "expected successful deserialization for {}. Error: {:?}",
                 serialized,
@@ -568,7 +567,7 @@ mod test {
                 record.amount.to_string(),
                 "expected: {}, actual: {}",
                 value,
-                record.amount.to_string()
+                record.amount
             );
         }
     }

--- a/src/str.rs
+++ b/src/str.rs
@@ -710,7 +710,7 @@ mod test {
     fn display_does_not_overflow_max_capacity() {
         let num = Decimal::from_str("1.2").unwrap();
         let mut buffer = ArrayString::<64>::new();
-        buffer.write_fmt(format_args!("{:.31}", num)).unwrap();
+        buffer.write_fmt(format_args!("{num:.31}")).unwrap();
         assert_eq!("1.2000000000000000000000000000000", buffer.as_str());
     }
 

--- a/src/str.rs
+++ b/src/str.rs
@@ -710,7 +710,7 @@ mod test {
     fn display_does_not_overflow_max_capacity() {
         let num = Decimal::from_str("1.2").unwrap();
         let mut buffer = ArrayString::<64>::new();
-        let _ = buffer.write_fmt(format_args!("{:.31}", num)).unwrap();
+        buffer.write_fmt(format_args!("{:.31}", num)).unwrap();
         assert_eq!("1.2000000000000000000000000000000", buffer.as_str());
     }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -19,8 +19,8 @@ fn it_can_extract_the_mantissa() {
     ];
     for &(input, mantissa, scale) in &tests {
         let num = Decimal::from_str(input).unwrap();
-        assert_eq!(num.mantissa(), mantissa, "Mantissa for {}", input);
-        assert_eq!(num.scale(), scale, "Scale for {}", input);
+        assert_eq!(num.mantissa(), mantissa, "Mantissa for {input}");
+        assert_eq!(num.scale(), scale, "Scale for {input}");
     }
 }
 
@@ -255,7 +255,7 @@ fn it_can_deserialize_unbounded_values() {
     ];
     for &(bytes, expected) in &tests {
         let dec = Decimal::deserialize(bytes);
-        let string = format!("{:.9999}", dec);
+        let string = format!("{dec:.9999}");
         let dec2 = Decimal::from_str(&string).unwrap();
         assert_eq!(dec, dec2);
         assert_eq!(dec.to_string(), expected, "dec.to_string()");
@@ -268,74 +268,74 @@ fn it_can_deserialize_unbounded_values() {
 #[test]
 fn it_formats() {
     let a = Decimal::from_str("233.323223").unwrap();
-    assert_eq!(format!("{}", a), "233.323223");
-    assert_eq!(format!("{:.9}", a), "233.323223000");
-    assert_eq!(format!("{:.0}", a), "233");
-    assert_eq!(format!("{:.2}", a), "233.32");
-    assert_eq!(format!("{:010.2}", a), "0000233.32");
-    assert_eq!(format!("{:0<10.2}", a), "233.320000");
+    assert_eq!(format!("{a}"), "233.323223");
+    assert_eq!(format!("{a:.9}"), "233.323223000");
+    assert_eq!(format!("{a:.0}"), "233");
+    assert_eq!(format!("{a:.2}"), "233.32");
+    assert_eq!(format!("{a:010.2}"), "0000233.32");
+    assert_eq!(format!("{a:0<10.2}"), "233.320000");
 }
 #[test]
 fn it_formats_neg() {
     let a = Decimal::from_str("-233.323223").unwrap();
-    assert_eq!(format!("{}", a), "-233.323223");
-    assert_eq!(format!("{:.9}", a), "-233.323223000");
-    assert_eq!(format!("{:.0}", a), "-233");
-    assert_eq!(format!("{:.2}", a), "-233.32");
-    assert_eq!(format!("{:010.2}", a), "-000233.32");
-    assert_eq!(format!("{:0<10.2}", a), "-233.32000");
+    assert_eq!(format!("{a}"), "-233.323223");
+    assert_eq!(format!("{a:.9}"), "-233.323223000");
+    assert_eq!(format!("{a:.0}"), "-233");
+    assert_eq!(format!("{a:.2}"), "-233.32");
+    assert_eq!(format!("{a:010.2}"), "-000233.32");
+    assert_eq!(format!("{a:0<10.2}"), "-233.32000");
 }
 #[test]
 fn it_formats_small() {
     let a = Decimal::from_str("0.2223").unwrap();
-    assert_eq!(format!("{}", a), "0.2223");
-    assert_eq!(format!("{:.9}", a), "0.222300000");
-    assert_eq!(format!("{:.0}", a), "0");
-    assert_eq!(format!("{:.2}", a), "0.22");
-    assert_eq!(format!("{:010.2}", a), "0000000.22");
-    assert_eq!(format!("{:0<10.2}", a), "0.22000000");
+    assert_eq!(format!("{a}"), "0.2223");
+    assert_eq!(format!("{a:.9}"), "0.222300000");
+    assert_eq!(format!("{a:.0}"), "0");
+    assert_eq!(format!("{a:.2}"), "0.22");
+    assert_eq!(format!("{a:010.2}"), "0000000.22");
+    assert_eq!(format!("{a:0<10.2}"), "0.22000000");
 }
 #[test]
 fn it_formats_small_leading_zeros() {
     let a = Decimal::from_str("0.0023554701772169").unwrap();
-    assert_eq!(format!("{}", a), "0.0023554701772169");
-    assert_eq!(format!("{:.9}", a), "0.002355470");
-    assert_eq!(format!("{:.0}", a), "0");
-    assert_eq!(format!("{:.2}", a), "0.00");
-    assert_eq!(format!("{:010.2}", a), "0000000.00");
-    assert_eq!(format!("{:0<10.2}", a), "0.00000000");
+    assert_eq!(format!("{a}"), "0.0023554701772169");
+    assert_eq!(format!("{a:.9}"), "0.002355470");
+    assert_eq!(format!("{a:.0}"), "0");
+    assert_eq!(format!("{a:.2}"), "0.00");
+    assert_eq!(format!("{a:010.2}"), "0000000.00");
+    assert_eq!(format!("{a:0<10.2}"), "0.00000000");
 }
 #[test]
 fn it_formats_small_neg() {
     let a = Decimal::from_str("-0.2223").unwrap();
-    assert_eq!(format!("{}", a), "-0.2223");
-    assert_eq!(format!("{:.9}", a), "-0.222300000");
-    assert_eq!(format!("{:.0}", a), "-0");
-    assert_eq!(format!("{:.2}", a), "-0.22");
-    assert_eq!(format!("{:010.2}", a), "-000000.22");
-    assert_eq!(format!("{:0<10.2}", a), "-0.2200000");
+    assert_eq!(format!("{a}"), "-0.2223");
+    assert_eq!(format!("{a:.9}"), "-0.222300000");
+    assert_eq!(format!("{a:.0}"), "-0");
+    assert_eq!(format!("{a:.2}"), "-0.22");
+    assert_eq!(format!("{a:010.2}"), "-000000.22");
+    assert_eq!(format!("{a:0<10.2}"), "-0.2200000");
 }
 
 #[test]
 fn it_formats_zero() {
     let a = Decimal::from_str("0").unwrap();
-    assert_eq!(format!("{}", a), "0");
-    assert_eq!(format!("{:.9}", a), "0.000000000");
-    assert_eq!(format!("{:.0}", a), "0");
-    assert_eq!(format!("{:.2}", a), "0.00");
-    assert_eq!(format!("{:010.2}", a), "0000000.00");
-    assert_eq!(format!("{:0<10.2}", a), "0.00000000");
+    assert_eq!(format!("{a}"), "0");
+    assert_eq!(format!("{a:.9}"), "0.000000000");
+    assert_eq!(format!("{a:.0}"), "0");
+    assert_eq!(format!("{a:.2}"), "0.00");
+    assert_eq!(format!("{a:010.2}"), "0000000.00");
+    assert_eq!(format!("{a:0<10.2}"), "0.00000000");
 }
 
 #[test]
 fn it_formats_int() {
     let a = Decimal::from_str("5").unwrap();
-    assert_eq!(format!("{}", a), "5");
-    assert_eq!(format!("{:.9}", a), "5.000000000");
-    assert_eq!(format!("{:.0}", a), "5");
-    assert_eq!(format!("{:.2}", a), "5.00");
-    assert_eq!(format!("{:010.2}", a), "0000005.00");
-    assert_eq!(format!("{:0<10.2}", a), "5.00000000");
+    assert_eq!(format!("{a}"), "5");
+    assert_eq!(format!("{a:.9}"), "5.000000000");
+    assert_eq!(format!("{a:.0}"), "5");
+    assert_eq!(format!("{a:.2}"), "5.00");
+    assert_eq!(format!("{a:010.2}"), "0000005.00");
+    assert_eq!(format!("{a:0<10.2}"), "5.00000000");
 }
 
 #[test]
@@ -349,7 +349,7 @@ fn it_formats_lower_exp() {
     ];
     for (value, expected) in &tests {
         let a = Decimal::from_str(value).unwrap();
-        assert_eq!(&format!("{:e}", a), *expected, "format!(\"{{:e}}\", {})", a);
+        assert_eq!(&format!("{a:e}"), *expected, "format!(\"{{:e}}\", {a})");
     }
 }
 
@@ -364,7 +364,7 @@ fn it_formats_lower_exp_padding() {
     ];
     for (value, expected) in &tests {
         let a = Decimal::from_str(value).unwrap();
-        assert_eq!(&format!("{:05e}", a), *expected, "format!(\"{{:05e}}\", {})", a);
+        assert_eq!(&format!("{a:05e}"), *expected, "format!(\"{{:05e}}\", {a})");
     }
 }
 
@@ -460,7 +460,7 @@ fn it_negates_decimals() {
     fn neg(a: &str, b: &str) {
         let a = Decimal::from_str(a).unwrap();
         let result = -a;
-        assert_eq!(b, result.to_string(), "- {}", a);
+        assert_eq!(b, result.to_string(), "- {a}");
     }
 
     let tests = &[
@@ -492,9 +492,9 @@ fn it_adds_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a + b;
-        assert_eq!(c, result.to_string(), "{} + {}", a, b);
+        assert_eq!(c, result.to_string(), "{a} + {b}");
         let result = b + a;
-        assert_eq!(c, result.to_string(), "{} + {}", b, a);
+        assert_eq!(c, result.to_string(), "{b} + {a}");
     }
 
     let tests = &[
@@ -627,7 +627,7 @@ fn it_subtracts_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a - b;
-        assert_eq!(c, result.to_string(), "{} - {}", a, b);
+        assert_eq!(c, result.to_string(), "{a} - {b}");
     }
 
     let tests = &[
@@ -688,9 +688,9 @@ fn it_multiplies_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a * b;
-        assert_eq!(c, result.to_string(), "{} * {}", a, b);
+        assert_eq!(c, result.to_string(), "{a} * {b}");
         let result = b * a;
-        assert_eq!(c, result.to_string(), "{} * {}", b, a);
+        assert_eq!(c, result.to_string(), "{b} * {a}");
     }
 
     let tests = &[
@@ -777,7 +777,7 @@ fn it_divides_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a / b;
-        assert_eq!(c, result.to_string(), "{} / {}", a, b);
+        assert_eq!(c, result.to_string(), "{a} / {b}");
     }
 
     let tests = &[
@@ -863,7 +863,7 @@ fn it_rems_decimals() {
         let b = Decimal::from_str(b).unwrap();
         // a = qb + r
         let result = a % b;
-        assert_eq!(c, result.to_string(), "{} % {}", a, b);
+        assert_eq!(c, result.to_string(), "{a} % {b}");
     }
 
     let tests = &[
@@ -913,8 +913,8 @@ fn it_eqs_decimals() {
     fn eq(a: &str, b: &str, c: bool) {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
-        assert_eq!(c, a.eq(&b), "{} == {}", a, b);
-        assert_eq!(c, b.eq(&a), "{} == {}", b, a);
+        assert_eq!(c, a.eq(&b), "{a} == {b}");
+        assert_eq!(c, b.eq(&a), "{b} == {a}");
     }
 
     let tests = &[
@@ -2095,7 +2095,7 @@ fn it_floors_decimals() {
     ];
     for &(a, expected) in tests {
         let a = Decimal::from_str(a).unwrap();
-        assert_eq!(expected, a.floor().to_string(), "Failed flooring {}", a);
+        assert_eq!(expected, a.floor().to_string(), "Failed flooring {a}");
     }
 }
 
@@ -2111,7 +2111,7 @@ fn it_ceils_decimals() {
     ];
     for &(a, expected) in tests {
         let a = Decimal::from_str(a).unwrap();
-        assert_eq!(expected, a.ceil().to_string(), "Failed ceiling {}", a);
+        assert_eq!(expected, a.ceil().to_string(), "Failed ceiling {a}");
     }
 }
 
@@ -2169,16 +2169,12 @@ fn it_can_parse_from_i32() {
         assert_eq!(
             expected,
             parsed.to_string(),
-            "expected {} does not match parsed {}",
-            expected,
-            parsed
+            "expected {expected} does not match parsed {parsed}"
         );
         assert_eq!(
             input.to_string(),
             parsed.to_string(),
-            "i32 to_string {} does not match parsed {}",
-            input,
-            parsed
+            "i32 to_string {input} does not match parsed {parsed}"
         );
     }
 }
@@ -2199,16 +2195,12 @@ fn it_can_parse_from_i64() {
         assert_eq!(
             expected,
             parsed.to_string(),
-            "expected {} does not match parsed {}",
-            expected,
-            parsed
+            "expected {expected} does not match parsed {parsed}"
         );
         assert_eq!(
             input.to_string(),
             parsed.to_string(),
-            "i64 to_string {} does not match parsed {}",
-            input,
-            parsed
+            "i64 to_string {input} does not match parsed {parsed}"
         );
     }
 }
@@ -2276,7 +2268,7 @@ fn it_can_round_using_basic_midpoint_rules() {
     for &(input, strategy, expected) in tests {
         let a = Decimal::from_str(input).unwrap();
         let b = a.round_dp_with_strategy(0, strategy);
-        assert_eq!(expected, b.to_string(), "{} > {} for {:?}", input, expected, strategy);
+        assert_eq!(expected, b.to_string(), "{input} > {expected} for {strategy:?}");
     }
 }
 
@@ -2614,10 +2606,10 @@ fn it_can_round_significant_figures() {
         let input = Decimal::from_str(input).unwrap();
         let result = input.round_sf(sf);
         if let Some(expected) = expected {
-            assert!(result.is_some(), "Expected result for {}.round_sf({})", input, sf);
-            assert_eq!(expected, result.unwrap().to_string(), "{}.round_sf({})", input, sf);
+            assert!(result.is_some(), "Expected result for {input}.round_sf({sf})");
+            assert_eq!(expected, result.unwrap().to_string(), "{input}.round_sf({sf})");
         } else {
-            assert!(result.is_none(), "Unexpected result for {}.round_sf({})", input, sf);
+            assert!(result.is_none(), "Unexpected result for {input}.round_sf({sf})");
         }
     }
 }
@@ -2639,26 +2631,17 @@ fn it_can_round_significant_figures_with_strategy() {
         if let Some(expected) = expected {
             assert!(
                 result.is_some(),
-                "Expected result for {}.round_sf_with_strategy({}, {:?})",
-                input,
-                sf,
-                strategy
+                "Expected result for {input}.round_sf_with_strategy({sf}, {strategy:?})"
             );
             assert_eq!(
                 expected,
                 result.unwrap().to_string(),
-                "{}.round_sf_with_strategy({}, {:?})",
-                input,
-                sf,
-                strategy
+                "{input}.round_sf_with_strategy({sf}, {strategy:?})"
             );
         } else {
             assert!(
                 result.is_none(),
-                "Unexpected result for {}.round_sf_with_strategy({}, {:?})",
-                input,
-                sf,
-                strategy
+                "Unexpected result for {input}.round_sf_with_strategy({sf}, {strategy:?})"
             );
         }
     }
@@ -2860,7 +2843,7 @@ fn it_converts_to_i64() {
     for (input, expected) in tests {
         let input = Decimal::from_str(input).unwrap();
         let actual = input.to_i64();
-        assert_eq!(expected, actual, "Input: {}", input);
+        assert_eq!(expected, actual, "Input: {input}");
     }
 }
 
@@ -2974,14 +2957,12 @@ fn it_converts_from_f32() {
         assert_eq!(
             expected,
             Decimal::from_f32(input).unwrap().to_string(),
-            "from_f32({})",
-            input
+            "from_f32({input})"
         );
         assert_eq!(
             expected,
             Decimal::try_from(input).unwrap().to_string(),
-            "try_from({})",
-            input
+            "try_from({input})"
         );
     }
 }
@@ -3015,8 +2996,7 @@ fn it_converts_from_f32_retaining_bits() {
         assert_eq!(
             expected,
             Decimal::from_f32_retain(input).unwrap().to_string(),
-            "from_f32_retain({})",
-            input
+            "from_f32_retain({input})"
         );
     }
 }
@@ -3043,14 +3023,12 @@ fn it_converts_from_f64() {
         assert_eq!(
             expected,
             Decimal::from_f64(input).unwrap().to_string(),
-            "from_f64({})",
-            input
+            "from_f64({input})"
         );
         assert_eq!(
             expected,
             Decimal::try_from(input).unwrap().to_string(),
-            "try_from({})",
-            input
+            "try_from({input})"
         );
     }
 }
@@ -3084,8 +3062,7 @@ fn it_converts_from_f64_retaining_bits() {
         assert_eq!(
             expected,
             Decimal::from_f64_retain(input).unwrap().to_string(),
-            "from_f64_retain({})",
-            input
+            "from_f64_retain({input})"
         );
     }
 }
@@ -3244,8 +3221,7 @@ fn it_can_reject_invalid_formats() {
     for &value in tests {
         assert!(
             Decimal::from_str(value).is_err(),
-            "This succeeded unexpectedly: {}",
-            value
+            "This succeeded unexpectedly: {value}"
         );
     }
 }
@@ -3262,7 +3238,7 @@ fn it_can_reject_large_numbers_with_panic() {
     ];
     for &value in tests {
         if let Ok(out) = Decimal::from_str(value) {
-            panic!("Unexpectedly parsed {} into {}", value, out)
+            panic!("Unexpectedly parsed {value} into {out}")
         }
     }
 }
@@ -3356,9 +3332,7 @@ fn it_can_parse_different_radix() {
             assert_eq!(
                 expected,
                 result.unwrap().to_string(),
-                "Original input: {} radix {}",
-                input,
-                radix
+                "Original input: {input} radix {radix}"
             );
         }
     }
@@ -3370,7 +3344,7 @@ fn it_can_calculate_signum() {
 
     for &(input, expected) in tests {
         let input = Decimal::from_str(input).unwrap();
-        assert_eq!(expected, input.signum().to_i32().unwrap(), "Input: {}", input);
+        assert_eq!(expected, input.signum().to_i32().unwrap(), "Input: {input}");
     }
 }
 
@@ -3391,9 +3365,7 @@ fn it_can_calculate_abs_sub() {
         assert_eq!(
             expected,
             input1.abs_sub(&input2).to_i32().unwrap(),
-            "Input: {} {}",
-            input1,
-            input2
+            "Input: {input1} {input2}"
         );
     }
 }
@@ -3627,7 +3599,7 @@ fn test_is_integer() {
     ];
     for &(raw, integer) in tests {
         let value = Decimal::from_str(raw).unwrap();
-        assert_eq!(value.is_integer(), integer, "value: {}", raw)
+        assert_eq!(value.is_integer(), integer, "value: {raw}")
     }
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -29,7 +29,7 @@ fn it_can_extract_the_mantissa() {
 #[test]
 fn it_creates_a_new_negative_decimal() {
     let a = Decimal::new(-100, 2);
-    assert_eq!(a.is_sign_negative(), true);
+    assert!(a.is_sign_negative());
     assert_eq!(a.scale(), 2);
     assert_eq!("-1.00", a.to_string());
 }
@@ -37,12 +37,12 @@ fn it_creates_a_new_negative_decimal() {
 #[test]
 fn it_creates_a_new_decimal_using_numeric_boundaries() {
     let a = Decimal::new(i64::MAX, 2);
-    assert_eq!(a.is_sign_negative(), false);
+    assert!(!a.is_sign_negative());
     assert_eq!(a.scale(), 2);
     assert_eq!("92233720368547758.07", a.to_string());
 
     let b = Decimal::new(i64::MIN, 2);
-    assert_eq!(b.is_sign_negative(), true);
+    assert!(b.is_sign_negative());
     assert_eq!(b.scale(), 2);
     assert_eq!("-92233720368547758.08", b.to_string());
 }
@@ -56,7 +56,7 @@ fn it_parses_empty_string() {
 #[test]
 fn it_parses_positive_int_string() {
     let a = Decimal::from_str("233").unwrap();
-    assert_eq!(a.is_sign_negative(), false);
+    assert!(!a.is_sign_negative());
     assert_eq!(a.scale(), 0);
     assert_eq!("233", a.to_string());
 }
@@ -64,7 +64,7 @@ fn it_parses_positive_int_string() {
 #[test]
 fn it_parses_negative_int_string() {
     let a = Decimal::from_str("-233").unwrap();
-    assert_eq!(a.is_sign_negative(), true);
+    assert!(a.is_sign_negative());
     assert_eq!(a.scale(), 0);
     assert_eq!("-233", a.to_string());
 }
@@ -72,7 +72,7 @@ fn it_parses_negative_int_string() {
 #[test]
 fn it_parses_positive_float_string() {
     let a = Decimal::from_str("233.323223").unwrap();
-    assert_eq!(a.is_sign_negative(), false);
+    assert!(!a.is_sign_negative());
     assert_eq!(a.scale(), 6);
     assert_eq!("233.323223", a.to_string());
 }
@@ -80,7 +80,7 @@ fn it_parses_positive_float_string() {
 #[test]
 fn it_parses_negative_float_string() {
     let a = Decimal::from_str("-233.43343").unwrap();
-    assert_eq!(a.is_sign_negative(), true);
+    assert!(a.is_sign_negative());
     assert_eq!(a.scale(), 5);
     assert_eq!("-233.43343", a.to_string());
 }
@@ -88,7 +88,7 @@ fn it_parses_negative_float_string() {
 #[test]
 fn it_parses_positive_tiny_float_string() {
     let a = Decimal::from_str(".000001").unwrap();
-    assert_eq!(a.is_sign_negative(), false);
+    assert!(!a.is_sign_negative());
     assert_eq!(a.scale(), 6);
     assert_eq!("0.000001", a.to_string());
 }
@@ -96,7 +96,7 @@ fn it_parses_positive_tiny_float_string() {
 #[test]
 fn it_parses_negative_tiny_float_string() {
     let a = Decimal::from_str("-0.000001").unwrap();
-    assert_eq!(a.is_sign_negative(), true);
+    assert!(a.is_sign_negative());
     assert_eq!(a.scale(), 6);
     assert_eq!("-0.000001", a.to_string());
 }
@@ -448,11 +448,8 @@ fn it_formats_scientific_precision() {
         ),
     ] {
         assert_eq!(format!("{:e}", Decimal::new(num, scale)), expected_no_precision);
-        for i in 0..expected_precision.len() {
-            assert_eq!(
-                format!("{:.prec$e}", Decimal::new(num, scale), prec = i),
-                expected_precision[i]
-            );
+        for (i, precision) in expected_precision.iter().enumerate() {
+            assert_eq!(&format!("{:.prec$e}", Decimal::new(num, scale), prec = i), precision);
         }
     }
 }
@@ -463,7 +460,7 @@ fn it_negates_decimals() {
     fn neg(a: &str, b: &str) {
         let a = Decimal::from_str(a).unwrap();
         let result = -a;
-        assert_eq!(b, result.to_string(), "- {}", a.to_string());
+        assert_eq!(b, result.to_string(), "- {}", a);
     }
 
     let tests = &[
@@ -495,9 +492,9 @@ fn it_adds_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a + b;
-        assert_eq!(c, result.to_string(), "{} + {}", a.to_string(), b.to_string());
+        assert_eq!(c, result.to_string(), "{} + {}", a, b);
         let result = b + a;
-        assert_eq!(c, result.to_string(), "{} + {}", b.to_string(), a.to_string());
+        assert_eq!(c, result.to_string(), "{} + {}", b, a);
     }
 
     let tests = &[
@@ -630,7 +627,7 @@ fn it_subtracts_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a - b;
-        assert_eq!(c, result.to_string(), "{} - {}", a.to_string(), b.to_string());
+        assert_eq!(c, result.to_string(), "{} - {}", a, b);
     }
 
     let tests = &[
@@ -691,9 +688,9 @@ fn it_multiplies_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a * b;
-        assert_eq!(c, result.to_string(), "{} * {}", a.to_string(), b.to_string());
+        assert_eq!(c, result.to_string(), "{} * {}", a, b);
         let result = b * a;
-        assert_eq!(c, result.to_string(), "{} * {}", b.to_string(), a.to_string());
+        assert_eq!(c, result.to_string(), "{} * {}", b, a);
     }
 
     let tests = &[
@@ -780,7 +777,7 @@ fn it_divides_decimals() {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
         let result = a / b;
-        assert_eq!(c, result.to_string(), "{} / {}", a.to_string(), b.to_string());
+        assert_eq!(c, result.to_string(), "{} / {}", a, b);
     }
 
     let tests = &[
@@ -866,7 +863,7 @@ fn it_rems_decimals() {
         let b = Decimal::from_str(b).unwrap();
         // a = qb + r
         let result = a % b;
-        assert_eq!(c, result.to_string(), "{} % {}", a.to_string(), b.to_string());
+        assert_eq!(c, result.to_string(), "{} % {}", a, b);
     }
 
     let tests = &[
@@ -916,8 +913,8 @@ fn it_eqs_decimals() {
     fn eq(a: &str, b: &str, c: bool) {
         let a = Decimal::from_str(a).unwrap();
         let b = Decimal::from_str(b).unwrap();
-        assert_eq!(c, a.eq(&b), "{} == {}", a.to_string(), b.to_string());
-        assert_eq!(c, b.eq(&a), "{} == {}", b.to_string(), a.to_string());
+        assert_eq!(c, a.eq(&b), "{} == {}", a, b);
+        assert_eq!(c, b.eq(&a), "{} == {}", b, a);
     }
 
     let tests = &[
@@ -946,13 +943,13 @@ fn it_cmps_decimals() {
             c,
             a.cmp(&b),
             "{} {} {}",
-            a.to_string(),
+            a,
             match c {
                 Less => "<",
                 Equal => "==",
                 Greater => ">",
             },
-            b.to_string()
+            b
         );
     }
 
@@ -3183,7 +3180,7 @@ fn it_can_parse_exact_highly_significant_numbers() {
         (".00000000000000000000000000001", Err(Error::Underflow)),
         (".10000000000000000000000000000", Err(Error::Underflow)),
     ];
-    for &(value, ref expected) in tests.into_iter() {
+    for &(value, ref expected) in tests.iter() {
         let actual = Decimal::from_str_exact(value).map(|d| d.to_string());
         assert_eq!(*expected, actual);
     }
@@ -3207,7 +3204,7 @@ fn it_can_parse_alternative_formats() {
 #[test]
 fn it_can_parse_fractional_numbers_with_underscore_separators() {
     let a = Decimal::from_str("0.1_23_456").unwrap();
-    assert_eq!(a.is_sign_negative(), false);
+    assert!(!a.is_sign_negative());
     assert_eq!(a.scale(), 6);
     assert_eq!("0.123456", a.to_string());
 }
@@ -3215,7 +3212,7 @@ fn it_can_parse_fractional_numbers_with_underscore_separators() {
 #[test]
 fn it_can_parse_numbers_with_underscore_separators_before_decimal_point() {
     let a = Decimal::from_str("1_234.56").unwrap();
-    assert_eq!(a.is_sign_negative(), false);
+    assert!(!a.is_sign_negative());
     assert_eq!(a.scale(), 2);
     assert_eq!("1234.56", a.to_string());
 }
@@ -4655,6 +4652,7 @@ mod proptest {
 }
 
 #[cfg(feature = "rocket-traits")]
+#[allow(clippy::disallowed_names)]
 mod rocket {
     use crate::Decimal;
     use rocket::form::{Form, FromForm};


### PR DESCRIPTION
* Added clippy configurations to ignore [digit/float related flags](https://github.com/mkatychev/rust-decimal/blob/2471658ea4470dd4f07e2d9c4581b5c453ba7e32/.cargo/config.toml#L6-L9)
* Ran `clippy --fix` after false positives were ignored
