### PR TITLE
Fixes issue with is_integer failing on decimal bounds

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -768,7 +768,7 @@ impl Decimal {
         let mut scale = scale;
         while scale > 0 {
             let remainder = if scale > 9 {
-                scale -= 10;
+                scale -= 9;
                 ops::array::div_by_u32(&mut bits, POWERS_10[9])
             } else {
                 let power = POWERS_10[scale as usize];

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3650,6 +3650,10 @@ fn test_is_integer() {
         ("1.1", false),
         ("3.1415926535897932384626433833", false),
         ("3.0000000000000000000000000000", true),
+        ("0.400000000", false),
+        ("0.4000000000", false),
+        ("0.4000000000000000000", false),
+        ("0.4000000000000000001", false),
     ];
     for &(raw, integer) in tests {
         let value = Decimal::from_str(raw).unwrap();


### PR DESCRIPTION
This fixes #604 

An issue was found where by precise integers >= scale 10 were being scaled back too aggressively causing numbers at an integer bound for the mantissa to be rounded toward the integer itself. 
It was effectively "skipping" a power of 10 during comparison - which when the mantissa was a power of 10 itself, would cause inaccurate results.
