### PR TITLE
Introduce wasm_bindgen support and expose a toNumber method for use in JavaScript

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
+wasm-bindgen = { default-features = false, optional = true, version = "0.2" }
 
 [dev-dependencies]
 bincode = { default-features = false, version = "1.0" }
@@ -81,6 +82,7 @@ serde-with-float = ["serde"]
 serde-with-str = ["serde"]
 std = ["arrayvec/std", "borsh?/std", "bytes?/std", "rand?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
+wasm-bindgen = ["dep:wasm-bindgen"]
 
 [[bench]]
 harness = false

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ assert_eq!(total, dec!(27.26));
 * [rocket-traits](#rocket-traits)
 * [rust-fuzz](#rust-fuzz)
 * [std](#std)
+* [wasm-bindgen](#wasm-bindgen)
 
 **Database**
 
@@ -296,6 +297,11 @@ pub struct OptionArbitraryExample {
 
 Enable `std` library support. This is enabled by default, however in the future will be opt in. For now, to support `no_std`
 libraries, this crate can be compiled with `--no-default-features`.
+
+### `wasm-bindgen`
+
+Enable [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) support which makes `Decimal` compatible with the
+`wasm_bindgen` attribute macro and exposes a `toNumber()` method for use in JavaScript.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ libraries, this crate can be compiled with `--no-default-features`.
 ### `wasm-bindgen`
 
 Enable [`wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) support which makes `Decimal` compatible with the
-`wasm_bindgen` attribute macro and exposes a `toNumber()` method for use in JavaScript.
+`wasm_bindgen` attribute macro and exposes `fromNumber()` and `toNumber()` methods to convert between `Decimal` and
+the primitive `number` type across boundaries.
 
 ## Building
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -27,6 +27,8 @@ use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::wasm_bindgen;
 
 /// The smallest value that can be represented by this decimal type.
 const MIN: Decimal = Decimal {
@@ -121,6 +123,7 @@ pub struct UnpackedDecimal {
     archive_attr(derive(Clone, Copy, Debug))
 )]
 #[cfg_attr(feature = "rkyv-safe", archive(check_bytes))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@ mod serde;
     )
 ))]
 pub mod serde;
+#[cfg(feature = "wasm-bindgen")]
+pub mod wasm;
 
 pub use decimal::{Decimal, RoundingStrategy};
 pub use error::Error;

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,0 +1,14 @@
+use num_traits::ToPrimitive;
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::Decimal;
+
+#[wasm_bindgen]
+impl Decimal {
+    /// Returns the value of this `Decimal` converted to a primitive number.
+    #[wasm_bindgen(js_name = toNumber)]
+    #[must_use]
+    pub fn to_number(&self) -> f64 {
+        self.to_f64().unwrap_or(f64::NAN)
+    }
+}

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,10 +1,17 @@
-use num_traits::ToPrimitive;
+use num_traits::{FromPrimitive, ToPrimitive};
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use crate::Decimal;
 
 #[wasm_bindgen]
 impl Decimal {
+    /// Returns a new `Decimal` object instance by converting a primitive number.
+    #[wasm_bindgen(js_name = fromNumber)]
+    #[must_use]
+    pub fn from_number(value: f64) -> Option<Decimal> {
+        Decimal::from_f64(value)
+    }
+
     /// Returns the value of this `Decimal` converted to a primitive number.
     #[wasm_bindgen(js_name = toNumber)]
     #[must_use]


### PR DESCRIPTION
I've been exploring potential implementations and would like to discuss an initial, lightweight contribution. Instead of fully binding and exporting the entire crate, my intention is to simplify it by exporting the `Decimal` type to JavaScript and making it possible to map it to a `number` type. I don't anticipate performing operations on `Decimal`s from the JavaScript side.

To achieve all of this, I've added a conditional attribute to the `Decimal` struct and introduced two methods within a conditional module, `Decimal::to_number` and `Decimal::from_number`, inspired by `decimal.js`. 

Fixes #613