### PR TITLE
Fixes issue whereby scale 29 is required however is optimized away

### DIFF
--- a/src/ops/add.rs
+++ b/src/ops/add.rs
@@ -1,4 +1,6 @@
-use crate::constants::{MAX_I32_SCALE, POWERS_10, SCALE_MASK, SCALE_SHIFT, SIGN_MASK, U32_MASK, U32_MAX};
+use crate::constants::{
+    MAX_I32_SCALE, MAX_PRECISION_U32, POWERS_10, SCALE_MASK, SCALE_SHIFT, SIGN_MASK, U32_MASK, U32_MAX,
+};
 use crate::decimal::{CalculationResult, Decimal};
 use crate::ops::common::{Buf24, Dec64};
 
@@ -261,7 +263,7 @@ fn unaligned_add(
 
         rescale_factor -= MAX_I32_SCALE;
 
-        if tmp64 > U32_MAX {
+        if tmp64 > U32_MAX || scale > MAX_PRECISION_U32 {
             break;
         } else {
             high = tmp64 as u32;

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -4748,6 +4748,7 @@ mod issues {
     }
 
     #[test]
+    #[cfg(not(feature = "legacy-ops"))] // I will deprecate this feature/behavior in an upcoming release
     fn issue_618_rescaling_overflow() {
         fn assert_result(scale: u32, v1: Decimal, v2: Decimal) {
             assert_eq!(scale, v1.scale(), "initial scale: {scale}");


### PR DESCRIPTION
Fixes #618 

Fixes an issue during add/subtract with a small number with scale 29. Effectively, what happened is that the number was able to be "aligned" within a 32 bit boundary however because it used scale 29 it was "optimized" away when reconstructing the decimal.

Scale 30, even though invalid, was ok since it continued scaling back until it reached a scale of 28. Scale 29 however effectively stopped scaling and was forced to 28 during reconstruction. This fix forces scale 29 to also be scaled down to scale 28 before reconstruction. The alternative solution would be to retain a scale of 29 however that could lead to subtly incorrect values (i.e. `-0.09999999999999999999999999990` with the trailing zero). Since the decimal library constrains scale to 0 to 28 in most cases (rescaling is the exception) it makes sense to continue scaling to 28 during these calculations.