### PR TITLE
Upgrade Borsh to resolve vulnerability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 [dependencies]
 arbitrary = { default-features = false, optional = true, version = "1.0" }
 arrayvec = { default-features = false, version = "0.7" }
-borsh = { default-features = false, optional = true, version = "1.1.1" }
+borsh = { default-features = false, features = ["derive", "unstable__schema"], optional = true, version = "1.1.1" }
 bytes = { default-features = false, optional = true, version = "1.0" }
 diesel1 = { default-features = false, optional = true, package = "diesel", version = "1.0" }
 diesel2 = { default-features = false, optional = true, package = "diesel", version = "2.1" }


### PR DESCRIPTION
This replaces / closes #616 - Borsh now requires feature flags to be provided to enable the derive macros that this feature was utilizing.

Ultimately it resolves https://rustsec.org/advisories/RUSTSEC-2023-0033.html.