### PR TITLE
Fixes precision issue with to_f64 with some numbers without fractions

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2354,7 +2354,7 @@ impl ToPrimitive for Decimal {
             let integer = self.to_i128();
             integer.map(|i| i as f64)
         } else {
-            let sign: f64 = if self.is_sign_negative() { -1.0 } else { 1.0 };
+            let neg = self.is_sign_negative();
             let mut mantissa: u128 = self.lo.into();
             mantissa |= (self.mid as u128) << 32;
             mantissa |= (self.hi as u128) << 64;
@@ -2364,16 +2364,24 @@ impl ToPrimitive for Decimal {
             let integral_part = mantissa / precision;
             let frac_part = mantissa % precision;
             let frac_f64 = (frac_part as f64) / (precision as f64);
-            let integral = sign * (integral_part as f64);
+            let integral = integral_part as f64;
             // If there is a fractional component then we will need to add that and remove any
             // inaccuracies that creep in during addition. Otherwise, if the fractional component
             // is zero we can exit early.
             if frac_f64.is_zero() {
+                if neg {
+                    return Some(-integral);
+                }
                 return Some(integral);
             }
             let value = integral + frac_f64;
             let round_to = 10f64.powi(self.scale() as i32);
-            Some((value * round_to).round() / round_to)
+            let rounded = (value * round_to).round() / round_to;
+            if neg {
+                Some(-rounded)
+            } else {
+                Some(rounded)
+            }
         }
     }
 }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2364,7 +2364,14 @@ impl ToPrimitive for Decimal {
             let integral_part = mantissa / precision;
             let frac_part = mantissa % precision;
             let frac_f64 = (frac_part as f64) / (precision as f64);
-            let value = sign * ((integral_part as f64) + frac_f64);
+            let integral = sign * (integral_part as f64);
+            // If there is a fractional component then we will need to add that and remove any
+            // inaccuracies that creep in during addition. Otherwise, if the fractional component
+            // is zero we can exit early.
+            if frac_f64.is_zero() {
+                return Some(integral);
+            }
+            let value = integral + frac_f64;
             let round_to = 10f64.powi(self.scale() as i32);
             Some((value * round_to).round() / round_to)
         }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -658,7 +658,7 @@ mod test {
 
     #[test]
     #[cfg(all(feature = "serde-str", not(feature = "serde-float")))]
-    fn bincode_serialization() {
+    fn bincode_serialization_not_float() {
         use bincode::{deserialize, serialize};
 
         let data = [
@@ -682,7 +682,7 @@ mod test {
 
     #[test]
     #[cfg(all(feature = "serde-str", feature = "serde-float"))]
-    fn bincode_serialization() {
+    fn bincode_serialization_serde_float() {
         use bincode::{deserialize, serialize};
 
         let data = [

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -2842,6 +2842,12 @@ fn it_converts_to_f64() {
         ("2.2238", Some(2.2238_f64)),
         ("2.2238123", Some(2.2238123_f64)),
         ("22238", Some(22238_f64)),
+        ("1000000", Some(1000000_f64)),
+        ("1000000.000000000000000000", Some(1000000_f64)),
+        ("10000", Some(10000_f64)),
+        ("10000.000000000000000000", Some(10000_f64)),
+        ("100000", Some(100000_f64)),
+        ("100000.000000000000000000", Some(100000_f64)),
     ];
     for &(value, expected) in tests {
         let value = Decimal::from_str(value).unwrap().to_f64();
@@ -4745,6 +4751,24 @@ mod issues {
         let c = a.checked_div(b);
         assert!(c.is_some());
         assert_eq!("-429391.87200000000002327170816", c.unwrap().to_string())
+    }
+
+    #[test]
+    fn issue_624_to_f64_precision() {
+        let tests = [
+            ("1000000.000000000000000000", 1000000.0f64),
+            ("10000.000000000000000000", 10000.0f64),
+            ("100000.000000000000000000", 100000.0f64), // Problematic value
+        ];
+        for (index, (test, expected)) in tests.iter().enumerate() {
+            let decimal = Decimal::from_str_exact(test).unwrap();
+            assert_eq!(
+                f64::try_from(decimal).unwrap(),
+                *expected,
+                "Test index {} failed",
+                index
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes #624 

When performing a conversion from `Decimal` to `f64` we would perform a round as the last step to remove any approximations that may have crept in during conversion. This works fairly well when there is a fractional component however is completely unnecessary when the number only has an integral component.

This removes the need to round if dealing with no fractional part.