### PR TITLE
Introduces `macros` feature and cleans up serde documentation a little bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Version History
 
+## 1.x
+
+### Added
+
+* `rust_decimal_macros` can now be utilized using the `macros` feature flag.
+
+### Changed
+
+* Added documentation for serde features as well as a few examples.
+
 ## 1.33.1
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ proptest = { default-features = false, optional = true, features = ["std"], vers
 rand = { default-features = false, optional = true, version = "0.8" }
 rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.42" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
+rust_decimal_macros = { default-features = false, optional = true, version = "1.33" } # This needs to be the n-1 published version
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
@@ -42,7 +43,7 @@ criterion = { default-features = false, version = "0.5" }
 csv = "1"
 futures = { default-features = false, version = "0.3" }
 rand = { default-features = false, features = ["getrandom"], version = "0.8" }
-rust_decimal_macros = { path = "macros" } # This should be ok since it's just for tests
+rust_decimal_macros = { default-features = false, version = "1.33" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"
 tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.0" }
@@ -50,6 +51,7 @@ version-sync = { default-features = false, features = ["html_root_url_updated", 
 
 [features]
 default = ["serde", "std"]
+macros = ["dep:rust_decimal_macros"]
 
 borsh = ["dep:borsh", "std"]
 c-repr = [] # Force Decimal to be repr(C)
@@ -88,4 +90,10 @@ name = "comparison"
 path = "benches/comparison.rs"
 
 [workspace]
-members = [".", "./macros"]
+members = [
+    ".",
+    "./macros",
+    "examples/*"
+]
+default-members = [".", "./macros"]
+resolver = "2"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,15 @@
+# Examples
+
+This contains some more advanced examples of using the rust decimal library of complex usage.
+
+All examples are crate based to demonstrate feature configurations. Examples can be run by using:
+
+```shell
+cargo run -p <example-name>
+```
+
+## serde-json-scenarios
+
+This example shows how to use the `serde` crate to serialize and deserialize the `Decimal` type using multiple different
+serialization formats.
+

--- a/examples/serde-json-scenarios/Cargo.toml
+++ b/examples/serde-json-scenarios/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "serde-json-scenarios"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+rust_decimal = { path = "../..", features = ["macros", "serde-with-arbitrary-precision"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["arbitrary_precision"]}

--- a/examples/serde-json-scenarios/src/main.rs
+++ b/examples/serde-json-scenarios/src/main.rs
@@ -1,0 +1,56 @@
+use rust_decimal::prelude::*;
+
+type ExampleResult = Result<(), Box<dyn std::error::Error>>;
+
+fn main() -> ExampleResult {
+    demonstrate_default_behavior()?;
+    demonstrate_arbitrary_precision_deserialization_with_string_serialization()?;
+    Ok(())
+}
+
+/// The default behavior of the library always expects string results. That is, it will serialize the
+/// Decimal as string, but also expect a string when deserializing.
+/// Note: this is not enough for bincode representations since there is no deserialization hint that the
+/// field is a string.
+fn demonstrate_default_behavior() -> ExampleResult {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Total {
+        value: Decimal,
+    }
+    let total = Total { value: dec!(1.23) };
+    let serialized = serde_json::to_string(&total)?;
+    assert_eq!(r#"{"value":"1.23"}"#, serialized);
+
+    // If we try to deserialize the same string we should succeed
+    let deserialized: Total = serde_json::from_str(&serialized)?;
+    assert_eq!(dec!(1.23), deserialized.value);
+
+    // Technically, by default we also support deserializing from a number, however this is doing a float
+    // conversion and is not recommended.
+    let deserialized: Total = serde_json::from_str(r#"{"value":1.23}"#)?;
+    assert_eq!(dec!(1.23), deserialized.value);
+    Ok(())
+}
+
+/// This demonstrates using arbitrary precision for a decimal value - even though the
+/// default string serialization behavior is baked in.
+fn demonstrate_arbitrary_precision_deserialization_with_string_serialization() -> ExampleResult {
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct Total {
+        #[serde(deserialize_with = "rust_decimal::serde::arbitrary_precision::deserialize")]
+        value: Decimal,
+    }
+
+    let total = Total { value: dec!(1.23) };
+    let serialized = serde_json::to_string(&total)?;
+    assert_eq!(r#"{"value":"1.23"}"#, serialized);
+
+    // If we try to deserialize the same string we should succeed
+    let deserialized: Total = serde_json::from_str(&serialized)?;
+    assert_eq!(dec!(1.23), deserialized.value);
+
+    // If we try to deserialize a float then this will succeed as well
+    let deserialized: Total = serde_json::from_str(r#"{"value":1.23}"#)?;
+    assert_eq!(dec!(1.23), deserialized.value);
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,9 @@ pub use error::Error;
 #[cfg(feature = "maths")]
 pub use maths::MathematicalOps;
 
+#[cfg(feature = "macros")]
+pub use rust_decimal_macros::dec;
+
 /// A convenience module appropriate for glob imports (`use rust_decimal::prelude::*;`).
 pub mod prelude {
     #[cfg(feature = "maths")]
@@ -64,6 +67,8 @@ pub mod prelude {
     pub use crate::{Decimal, RoundingStrategy};
     pub use core::str::FromStr;
     pub use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
+    #[cfg(feature = "macros")]
+    pub use rust_decimal_macros::dec;
 }
 
 #[cfg(all(feature = "diesel1", not(feature = "diesel2")))]

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -44,7 +44,7 @@ impl UniformSampler for DecimalSampler {
     ///
     /// ```
     /// # use rand::Rng;
-    /// # use rust_decimal_macros::dec;
+    /// # use rust_decimal::dec;
     /// let mut rng = rand::rngs::OsRng;
     /// let random = rng.gen_range(dec!(1.00)..dec!(2.00));
     /// assert!(random >= dec!(1.00));
@@ -71,7 +71,7 @@ impl UniformSampler for DecimalSampler {
     ///
     /// ```
     /// # use rand::Rng;
-    /// # use rust_decimal_macros::dec;
+    /// # use rust_decimal::dec;
     /// let mut rng = rand::rngs::OsRng;
     /// let random = rng.gen_range(dec!(1.00)..=dec!(2.00));
     /// assert!(random >= dec!(1.00));


### PR DESCRIPTION
This exposes `rust_decimal_macros` under the `macros` feature and cleans up the serde documentation a little bit. I introduced the `macros` feature as I was writing an example of how to use the feature!