### PR TITLE
Remove cargo-edit reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@ The binary representation consists of a 96 bit integer number, a scaling factor 
 
 ## Installing
 
-Using [`cargo-edit`](https://crates.io/crates/cargo-edit):
-
 ```sh
 $ cargo add rust_decimal
 ```


### PR DESCRIPTION
`cargo add` has been part of cargo for a long time. No other changes to invocations are needed.