### PR TITLE
Auto-document feature guarded items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ version = "1.33.1"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 arbitrary = { default-features = false, optional = true, version = "1.0" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 extern crate alloc;
 
 mod constants;


### PR DESCRIPTION
This is _wildly_ helpful on this sort of crate with lots of features and trait impls.

![2024-01-09_16 34 05-42be19aa](https://github.com/paupino/rust-decimal/assets/3316789/7783c3f9-e403-49ae-889c-1983e75f7038)
