### PR TITLE
Implement traits on the ArchivedDecimal.

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2586,7 +2586,18 @@ impl PartialEq for Decimal {
     }
 }
 
+#[cfg(feature = "rkyv")]
+impl PartialEq for ArchivedDecimal {
+    #[inline]
+    fn eq(&self, other: &ArchivedDecimal) -> bool {
+        self.cmp(other) == Equal
+    }
+}
 impl Eq for Decimal {}
+
+#[cfg(feature = "rkyv")]
+impl Eq for ArchivedDecimal {}
+
 
 impl Hash for Decimal {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -2605,9 +2616,32 @@ impl PartialOrd for Decimal {
     }
 }
 
+#[cfg(feature = "rkyv")]
+impl PartialOrd<Self> for ArchivedDecimal {
+    fn partial_cmp(&self, other: &ArchivedDecimal) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+#[cfg(feature = "rkyv")]
+impl PartialOrd<Decimal> for ArchivedDecimal {
+    fn partial_cmp(&self, other: &Decimal) -> Option<Ordering> {
+        let self_dec = Decimal { flags: self.flags, hi: self.hi, lo: self.lo, mid: self.mid };
+        Some(ops::cmp_impl(&self_dec, other))
+    }
+}
+
 impl Ord for Decimal {
     fn cmp(&self, other: &Decimal) -> Ordering {
         ops::cmp_impl(self, other)
+    }
+}
+
+#[cfg(feature = "rkyv")]
+impl Ord for ArchivedDecimal {
+    fn cmp(&self, other: &ArchivedDecimal) -> Ordering {
+        let self_dec = Decimal { flags: self.flags, hi: self.hi, lo: self.lo, mid: self.mid };
+        let other_dec = Decimal { flags: other.flags, hi: other.hi, lo: other.lo, mid: other.mid };
+        ops::cmp_impl(&self_dec, &other_dec)
     }
 }
 


### PR DESCRIPTION
rkyv generates a separate type `ArchivedDecimal`, which represents the serialized value. In this PR we implement several traits to allow for ordering and equality on the `ArchivedDecimal` type (according to the rules of the Decimal type).

We also implement comparison between `Decimal` and `ArchivedDecimal` (PartialOrd) which is helpful to efficiently compare e.g., a more complex in-memory type that uses decimal as part of its fields with the serialized counter-part.