### PR TITLE
Prevent scale of 29 when hydrating from unbound numeric data types in Postgresql

### DIFF
--- a/src/postgres/common.rs
+++ b/src/postgres/common.rs
@@ -78,7 +78,7 @@ impl Decimal {
 
         result.set_sign_negative(neg);
         // Rescale to the postgres value, automatically rounding as needed.
-        result.rescale(scale as u32);
+        result.rescale((scale as u32).min(MAX_PRECISION_U32));
         result
     }
 


### PR DESCRIPTION
This fixes #645 

The way this fixes things is to avoid scale of 29 being represented internally via the postgres driver. A scale of 29, while _technically_ available in some very minimal use cases is considered undefined behavior in rust-decimal and typically guarded against (i.e. it's very difficult, if not impossible, to reproduce this without going through the postgres driver).

Consequently, applying a ceiling to the rescale operation in this case is appropriate.

Added a couple of tests which both fail without the fix (i.e. reproducing the bug):

```
---- postgres::driver::test::read_small_unconstrained_numeric_type_addition stdout ----
thread 'postgres::driver::test::read_small_unconstrained_numeric_type_addition' panicked at src/postgres/driver.rs:292:9:
assertion `left == right` failed
  left: 10000000000014780214000000000
 right: 0.1000000000001478021400000000
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- postgres::driver::test::read_small_unconstrained_numeric_type stdout ----
thread 'postgres::driver::test::read_small_unconstrained_numeric_type' panicked at src/postgres/driver.rs:271:9:
assertion `left == right` failed
  left: "0.10000000000000000000000000000"
 right: "0.1000000000000000000000000000"
```