### PR TITLE
Replace feature-guarded dependencies on 'postgres' and 'tokio_postgres' with 'postgres_types'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ diesel1 = { default-features = false, optional = true, package = "diesel", versi
 diesel2 = { default-features = false, optional = true, package = "diesel", version = "2.1" }
 ndarray = { default-features = false, optional = true, version = "0.15.6" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
-postgres = { default-features = false, optional = true, version = "0.19" }
+postgres-types = { default-features = false, optional = true, version = "0.2" }
 proptest = { default-features = false, optional = true, features = ["std"], version = "1.0" }
 rand = { default-features = false, optional = true, version = "0.8" }
 rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.42" }
@@ -49,6 +49,8 @@ serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"
 tokio = { default-features = false, features = ["macros", "rt-multi-thread", "test-util"], version = "1.0" }
 version-sync = { default-features = false, features = ["html_root_url_updated", "markdown_deps_updated"], version = "0.9" }
+postgres = { default-features = false, version = "0.19" }
+tokio-postgres = { default-features = false, version = "0.7" }
 
 [features]
 default = ["serde", "std"]
@@ -63,8 +65,8 @@ db-diesel1-mysql = ["diesel1/mysql", "std"]
 db-diesel1-postgres = ["diesel1/postgres", "std"]
 db-diesel2-mysql = ["diesel2/mysql", "std"]
 db-diesel2-postgres = ["diesel2/postgres", "std"]
-db-postgres = ["dep:bytes", "dep:postgres", "std"]
-db-tokio-postgres = ["dep:bytes", "dep:postgres", "std", "dep:tokio-postgres"]
+db-postgres = ["dep:bytes", "dep:postgres-types", "std"]
+db-tokio-postgres = ["dep:bytes", "dep:postgres-types", "std"]
 legacy-ops = []
 maths = []
 maths-nopanic = ["maths"]

--- a/src/postgres/driver.rs
+++ b/src/postgres/driver.rs
@@ -1,7 +1,7 @@
 use crate::postgres::common::*;
 use crate::Decimal;
 use bytes::{BufMut, BytesMut};
-use postgres::types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
+use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use std::io::{Cursor, Read};
 
 fn read_two_bytes(cursor: &mut Cursor<&[u8]>) -> std::io::Result<[u8; 2]> {


### PR DESCRIPTION
This change modifies the tokio_postgres & postgres integration to use postgres_types (the underlying library powering both). This removes a massive amount of dependencies when any feature in `{db-postgres, db-tokio-postgres, tokio-pg}` is enabled.

<details>
  <summary>Before</summary>

```bash
% cargo tree -F db-tokio-postgres -e normal                                                                                                                                                                                                                                                      rust_decimal v1.34.3 (/Users/moritz/dev/rust-decimal)
├── arrayvec v0.7.4
├── bytes v1.5.0
├── num-traits v0.2.18
├── postgres v0.19.7
│   ├── bytes v1.5.0
│   ├── fallible-iterator v0.2.0
│   ├── futures-util v0.3.30
│   │   ├── futures-core v0.3.30
│   │   ├── futures-macro v0.3.30 (proc-macro)
│   │   │   ├── proc-macro2 v1.0.78
│   │   │   │   └── unicode-ident v1.0.12
│   │   │   ├── quote v1.0.35
│   │   │   │   └── proc-macro2 v1.0.78 (*)
│   │   │   └── syn v2.0.52
│   │   │       ├── proc-macro2 v1.0.78 (*)
│   │   │       ├── quote v1.0.35 (*)
│   │   │       └── unicode-ident v1.0.12
│   │   ├── futures-sink v0.3.30
│   │   ├── futures-task v0.3.30
│   │   ├── pin-project-lite v0.2.13
│   │   ├── pin-utils v0.1.0
│   │   └── slab v0.4.9
│   ├── log v0.4.21
│   ├── tokio v1.36.0
│   │   ├── bytes v1.5.0
│   │   ├── libc v0.2.153
│   │   ├── mio v0.8.11
│   │   │   └── libc v0.2.153
│   │   ├── pin-project-lite v0.2.13
│   │   └── socket2 v0.5.6
│   │       └── libc v0.2.153
│   └── tokio-postgres v0.7.10
│       ├── async-trait v0.1.77 (proc-macro)
│       │   ├── proc-macro2 v1.0.78 (*)
│       │   ├── quote v1.0.35 (*)
│       │   └── syn v2.0.52 (*)
│       ├── byteorder v1.5.0
│       ├── bytes v1.5.0
│       ├── fallible-iterator v0.2.0
│       ├── futures-channel v0.3.30
│       │   ├── futures-core v0.3.30
│       │   └── futures-sink v0.3.30
│       ├── futures-util v0.3.30 (*)
│       ├── log v0.4.21
│       ├── parking_lot v0.12.1
│       │   ├── lock_api v0.4.11
│       │   │   └── scopeguard v1.2.0
│       │   └── parking_lot_core v0.9.9
│       │       ├── cfg-if v1.0.0
│       │       ├── libc v0.2.153
│       │       └── smallvec v1.13.1
│       ├── percent-encoding v2.3.1
│       ├── phf v0.11.2
│       │   └── phf_shared v0.11.2
│       │       └── siphasher v0.3.11
│       ├── pin-project-lite v0.2.13
│       ├── postgres-protocol v0.6.6
│       │   ├── base64 v0.21.7
│       │   ├── byteorder v1.5.0
│       │   ├── bytes v1.5.0
│       │   ├── fallible-iterator v0.2.0
│       │   ├── hmac v0.12.1
│       │   │   └── digest v0.10.7
│       │   │       ├── block-buffer v0.10.4
│       │   │       │   └── generic-array v0.14.7
│       │   │       │       └── typenum v1.17.0
│       │   │       ├── crypto-common v0.1.6
│       │   │       │   ├── generic-array v0.14.7 (*)
│       │   │       │   └── typenum v1.17.0
│       │   │       └── subtle v2.5.0
│       │   ├── md-5 v0.10.6
│       │   │   ├── cfg-if v1.0.0
│       │   │   └── digest v0.10.7 (*)
│       │   ├── memchr v2.7.1
│       │   ├── rand v0.8.5
│       │   │   ├── libc v0.2.153
│       │   │   ├── rand_chacha v0.3.1
│       │   │   │   ├── ppv-lite86 v0.2.17
│       │   │   │   └── rand_core v0.6.4
│       │   │   │       └── getrandom v0.2.12
│       │   │   │           ├── cfg-if v1.0.0
│       │   │   │           └── libc v0.2.153
│       │   │   └── rand_core v0.6.4 (*)
│       │   ├── sha2 v0.10.8
│       │   │   ├── cfg-if v1.0.0
│       │   │   ├── cpufeatures v0.2.12
│       │   │   │   └── libc v0.2.153
│       │   │   └── digest v0.10.7 (*)
│       │   └── stringprep v0.1.4
│       │       ├── finl_unicode v1.2.0
│       │       ├── unicode-bidi v0.3.15
│       │       └── unicode-normalization v0.1.23
│       │           └── tinyvec v1.6.0
│       │               └── tinyvec_macros v0.1.1
│       ├── postgres-types v0.2.6
│       │   ├── bytes v1.5.0
│       │   ├── fallible-iterator v0.2.0
│       │   └── postgres-protocol v0.6.6 (*)
│       ├── rand v0.8.5 (*)
│       ├── socket2 v0.5.6 (*)
│       ├── tokio v1.36.0 (*)
│       ├── tokio-util v0.7.10
│       │   ├── bytes v1.5.0
│       │   ├── futures-core v0.3.30
│       │   ├── futures-sink v0.3.30
│       │   ├── pin-project-lite v0.2.13
│       │   ├── tokio v1.36.0 (*)
│       │   └── tracing v0.1.40
│       │       ├── pin-project-lite v0.2.13
│       │       └── tracing-core v0.1.32
│       │           └── once_cell v1.19.0
│       └── whoami v1.5.0
├── serde v1.0.197
└── tokio-postgres v0.7.10 (*)  
  ```

</details>

<details>
  <summary>After</summary>

```bash
% cargo tree -F db-tokio-postgres -e normal                                                                                                                                                                                                                                                     
├── arrayvec v0.7.4
├── bytes v1.5.0
├── num-traits v0.2.18
├── postgres-types v0.2.6
│   ├── bytes v1.5.0
│   ├── fallible-iterator v0.2.0
│   └── postgres-protocol v0.6.6
│       ├── base64 v0.21.7
│       ├── byteorder v1.5.0
│       ├── bytes v1.5.0
│       ├── fallible-iterator v0.2.0
│       ├── hmac v0.12.1
│       │   └── digest v0.10.7
│       │       ├── block-buffer v0.10.4
│       │       │   └── generic-array v0.14.7
│       │       │       └── typenum v1.17.0
│       │       ├── crypto-common v0.1.6
│       │       │   ├── generic-array v0.14.7 (*)
│       │       │   └── typenum v1.17.0
│       │       └── subtle v2.5.0
│       ├── md-5 v0.10.6
│       │   ├── cfg-if v1.0.0
│       │   └── digest v0.10.7 (*)
│       ├── memchr v2.7.1
│       ├── rand v0.8.5
│       │   ├── libc v0.2.153
│       │   ├── rand_chacha v0.3.1
│       │   │   ├── ppv-lite86 v0.2.17
│       │   │   └── rand_core v0.6.4
│       │   │       └── getrandom v0.2.12
│       │   │           ├── cfg-if v1.0.0
│       │   │           └── libc v0.2.153
│       │   └── rand_core v0.6.4 (*)
│       ├── sha2 v0.10.8
│       │   ├── cfg-if v1.0.0
│       │   ├── cpufeatures v0.2.12
│       │   │   └── libc v0.2.153
│       │   └── digest v0.10.7 (*)
│       └── stringprep v0.1.4
│           ├── finl_unicode v1.2.0
│           ├── unicode-bidi v0.3.15
│           └── unicode-normalization v0.1.23
│               └── tinyvec v1.6.0
│                   └── tinyvec_macros v0.1.1
└── serde v1.0.197
```

</details>