### PR TITLE
Fix FromSql for Postgres Numeric NaNs

### DIFF
--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3516,7 +3516,7 @@ fn postgres_to_from_sql() {
 
 #[cfg(feature = "db-postgres")]
 #[test]
-fn from_sql_special_numeric() {
+fn postgres_from_sql_special_numeric() {
     use postgres::types::{FromSql, Kind, Type};
 
     // The numbers below are the big-endian equivalent of the NUMERIC_* masks for NAN, PINF, NINF

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3475,7 +3475,7 @@ fn declarative_ref_dec_sum() {
 
 #[cfg(feature = "db-postgres")]
 #[test]
-fn to_from_sql() {
+fn postgres_to_from_sql() {
     use bytes::BytesMut;
     use postgres::types::{FromSql, Kind, ToSql, Type};
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3473,7 +3473,7 @@ fn declarative_ref_dec_sum() {
     assert_eq!(sum, Decimal::from(45))
 }
 
-#[cfg(feature = "postgres")]
+#[cfg(feature = "db-postgres")]
 #[test]
 fn to_from_sql() {
     use bytes::BytesMut;
@@ -3511,6 +3511,36 @@ fn to_from_sql() {
         let output = Decimal::from_sql(&t, &bytes).unwrap();
 
         assert_eq!(input, output);
+    }
+}
+
+#[cfg(feature = "db-postgres")]
+#[test]
+fn from_sql_special_numeric() {
+    use postgres::types::{FromSql, Kind, Type};
+
+    // The numbers below are the big-endian equivalent of the NUMERIC_* masks for NAN, PINF, NINF
+    let tests = &[
+        ("NaN", &[0, 0, 0, 0, 192, 0, 0, 0]),
+        ("Infinity", &[0, 0, 0, 0, 208, 0, 0, 0]),
+        ("-Infinity", &[0, 0, 0, 0, 240, 0, 0, 0]),
+    ];
+
+    let t = Type::new("".into(), 0, Kind::Simple, "".into());
+
+    for (name, bytes) in tests {
+        let res = Decimal::from_sql(&t, *bytes);
+        match &res {
+            Ok(_) => panic!("Expected error, got Ok"),
+            Err(e) => {
+                let error_message = e.to_string();
+                assert!(
+                    error_message.contains(name),
+                    "Error message does not contain the expected value: {}",
+                    name
+                );
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This fixes a bug where from_sql was converting Numeric::NaN to 0 rather than returning an error.

It also returns a more descriptive error message when from_sql is called with Numeric Infinity and -Infinity, which are also not representable in Decimal.

Closes #655

Side note: Unless I am missing something, it seems like the to_from_sql test wasn't actually being run since the `postgres` feature seems to no longer be a thing. I was able to get it to run by changing the cfg to `db-postgres`, so I added that to this commit as well.