### PR TITLE
Replace filtery with a strategy for implementation of proptest::Arbitrary

### DIFF
--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -2,23 +2,17 @@ use crate::Decimal;
 
 use proptest::arbitrary::{Arbitrary, StrategyFor};
 use proptest::prelude::*;
-use proptest::strategy::FilterMap;
+use proptest::strategy::Map;
+use std::ops::RangeInclusive;
 
 impl Arbitrary for Decimal {
     type Parameters = ();
-    type Strategy = FilterMap<StrategyFor<(u32, u32, u32, bool, u8)>, fn((u32, u32, u32, bool, u8)) -> Option<Self>>;
+    type Strategy =
+        Map<(StrategyFor<(u32, u32, u32, bool)>, RangeInclusive<u8>), fn(((u32, u32, u32, bool), u8)) -> Self>;
 
     fn arbitrary_with(_parameters: Self::Parameters) -> Self::Strategy {
         // generate 3 arbitrary u32, a bool and an u32 between 0 to 28
-        any::<(u32, u32, u32, bool, u8)>().prop_filter_map(
-            "scale must be between 0..28",
-            |(lo, mid, hi, negative, scale)| {
-                if scale <= 28 {
-                    Some(Decimal::from_parts(lo, mid, hi, negative, scale as u32))
-                } else {
-                    None
-                }
-            },
-        )
+        (any::<(u32, u32, u32, bool)>(), 0..=28)
+            .prop_map(|((lo, mid, hi, negative), scale)| Decimal::from_parts(lo, mid, hi, negative, scale as u32))
     }
 }

--- a/src/proptest.rs
+++ b/src/proptest.rs
@@ -1,18 +1,18 @@
 use crate::Decimal;
 
+use core::ops::RangeInclusive;
 use proptest::arbitrary::{Arbitrary, StrategyFor};
 use proptest::prelude::*;
 use proptest::strategy::Map;
-use std::ops::RangeInclusive;
 
 impl Arbitrary for Decimal {
     type Parameters = ();
-    type Strategy =
-        Map<(StrategyFor<(u32, u32, u32, bool)>, RangeInclusive<u8>), fn(((u32, u32, u32, bool), u8)) -> Self>;
-
     fn arbitrary_with(_parameters: Self::Parameters) -> Self::Strategy {
         // generate 3 arbitrary u32, a bool and an u32 between 0 to 28
         (any::<(u32, u32, u32, bool)>(), 0..=28)
             .prop_map(|((lo, mid, hi, negative), scale)| Decimal::from_parts(lo, mid, hi, negative, scale as u32))
     }
+
+    type Strategy =
+        Map<(StrategyFor<(u32, u32, u32, bool)>, RangeInclusive<u8>), fn(((u32, u32, u32, bool), u8)) -> Self>;
 }


### PR DESCRIPTION
Currently the `proptest::Arbitrary` implementation uses `filter_map` with failure rate of ~90%. This causes problems if user need to filter it further.

This change replaces it with using a range removing backtracing.