### PR TITLE
serde.rs: Fix type infer error

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -269,7 +269,7 @@ pub mod str_option {
         match *value {
             Some(ref decimal) => {
                 let decimal = crate::str::to_str_internal(decimal, true, None);
-                serializer.serialize_some(decimal.0.as_ref())
+                serializer.serialize_some::<str>(decimal.0.as_ref())
             }
             None => serializer.serialize_none(),
         }


### PR DESCRIPTION
Fixes #669

This error is caused by latest `arrayvec` crate `0.7.6` which now implements 2 different versions `AsRef` traits.
- [here](https://github.com/bluss/arrayvec/blob/master/src/array_string.rs#L496-L499) as `AsRef<str>`
- and [here](https://github.com/bluss/arrayvec/blob/master/src/array_string.rs#L507-L511) as `AsRef<Path>`