### PR TITLE
Use repr(C) and add optional bytemuck support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ rustdoc-args = ["--cfg", "docsrs"]
 arbitrary = { default-features = false, optional = true, version = "1.0" }
 arrayvec = { default-features = false, version = "0.7" }
 borsh = { default-features = false, features = ["derive", "unstable__schema"], optional = true, version = "1.1.1" }
+bytemuck = { default-features = false, optional = true, version = "1.17.1" }
+bytemuck_derive = { default-features = false, optional = true, version = "1.7.1" }
 bytes = { default-features = false, optional = true, version = "1.0" }
 diesel = { default-features = false, optional = true, version = "2.2" }
 ndarray = { default-features = false, optional = true, version = "0.15.6" }
@@ -57,6 +59,7 @@ default = ["serde", "std"]
 #macros = ["dep:rust_decimal_macros"]
 
 borsh = ["dep:borsh", "std"]
+bytemuck = ["dep:bytemuck", "dep:bytemuck_derive"]
 c-repr = [] # Force Decimal to be repr(C)
 db-diesel-mysql = ["diesel/mysql", "std"]
 db-diesel-postgres = ["diesel/postgres", "std"]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -106,12 +106,17 @@ pub struct UnpackedDecimal {
     derive(borsh::BorshDeserialize, borsh::BorshSerialize, borsh::BorshSchema)
 )]
 #[cfg_attr(
+    feature = "bytemuck",
+    derive(bytemuck_derive::Pod, bytemuck_derive::Zeroable)
+)]
+#[cfg_attr(
     feature = "rkyv",
     derive(Archive, Deserialize, Serialize),
     archive(compare(PartialEq)),
     archive_attr(derive(Clone, Copy, Debug))
 )]
 #[cfg_attr(feature = "rkyv-safe", archive(check_bytes))]
+#[repr(C)]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -105,10 +105,7 @@ pub struct UnpackedDecimal {
     feature = "borsh",
     derive(borsh::BorshDeserialize, borsh::BorshSerialize, borsh::BorshSchema)
 )]
-#[cfg_attr(
-    feature = "bytemuck",
-    derive(bytemuck_derive::Pod, bytemuck_derive::Zeroable)
-)]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::Pod, bytemuck_derive::Zeroable))]
 #[cfg_attr(
     feature = "rkyv",
     derive(Archive, Deserialize, Serialize),


### PR DESCRIPTION
Changes:

- Sets `repr(C)` on the `Decimal` struct
- Adds a `bytemuck` feature that derives `Pod` and `Zeroable` on `Decimal`