### PR TITLE
Implements serde-lexical

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ serde-str = ["serde-with-str"]
 serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std"]
 serde-with-float = ["serde"]
 serde-with-str = ["serde"]
+serde-lexical = ["std", "serde"]
 std = ["arrayvec/std", "borsh?/std", "bytes?/std", "rand?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 

--- a/make/tests/serde.toml
+++ b/make/tests/serde.toml
@@ -8,6 +8,7 @@ dependencies = [
     "test-serde-with-arbitrary-precision",
     "test-serde-with-float",
     "test-serde-with-str",
+    "test-serde-lexical",
 ]
 
 [tasks.test-serde-float]
@@ -41,3 +42,7 @@ args = ["test", "--workspace", "--tests", "--features=serde-with-float", "serde"
 [tasks.test-serde-with-str]
 command = "cargo"
 args = ["test", "--workspace", "--tests", "--features=serde-with-str", "serde", "--", "--skip", "generated"]
+
+[tasks.test-serde-lexical]
+command = "cargo"
+args = ["test", "--workspace", "--tests", "--features=serde-lexical", "serde", "--", "--skip", "generated"]


### PR DESCRIPTION
Implements another serialisation feature: `serde-lexical`

This serialisation preserves the lexical order in the serialized form.
This is particularly useful to keep the decimal ordered when stored as a key in a key-value store.

Possible fixes #610 