### PR TITLE
Fix `f64` dec limit edge case

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2190,6 +2190,9 @@ fn base2_to_decimal(
             exponent10 -= 1;
             exponent5 += 1;
             ops::array::shl1_internal(bits, 0);
+        } else if exponent10 * 2 > -exponent5 {
+            // Multiplying by >=2 which, due to the previous condition, means an overflow.
+            return None;
         } else {
             // The mantissa would overflow if shifted. Therefore it should be
             // directly divided by 5. This will lose significant digits, unless

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3144,7 +3144,6 @@ fn it_converts_from_f64_dec_limits() {
     let over_max = 79_228_162_514_264_355_185_729_994_752_f64;
     let max_plus_one = 79_228_162_514_264_337_593_543_950_336_f64;
     let under_max = 79_228_162_514_264_328_797_450_928_128_f64;
-    let max = 79_228_162_514_264_337_593_543_950_335_f64;
 
     assert!(
         Decimal::from_f64(over_max).is_none(),
@@ -3158,11 +3157,6 @@ fn it_converts_from_f64_dec_limits() {
         "79228162514264328797450928128",
         Decimal::from_f64(under_max).unwrap().to_string(),
         "from_f64(79_228_162_514_264_328_797_450_928_128_f64) -> some (inside limits)"
-    );
-    assert_eq!(
-        "79228162514264337593543950335",
-        Decimal::from_f64(max).unwrap().to_string(),
-        "from_f64(79_228_162_514_264_337_593_543_950_335_f64) -> some (at max)"
     );
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3140,22 +3140,29 @@ fn it_converts_from_f64_limits() {
 fn it_converts_from_f64_dec_limits() {
     use num_traits::FromPrimitive;
 
-    let max_next_up_next_up = 79228162514264355185729994752f64;
-    let max_next_up = 79228162514264337593543950336f64;
-    let max = 79228162514264328797450928128f64;
+    // Note Decimal MAX is: 79_228_162_514_264_337_593_543_950_335
+    let over_max = 79_228_162_514_264_355_185_729_994_752_f64;
+    let max_plus_one = 79_228_162_514_264_337_593_543_950_336_f64;
+    let under_max = 79_228_162_514_264_328_797_450_928_128_f64;
+    let max = 79_228_162_514_264_337_593_543_950_335_f64;
 
     assert!(
-        Decimal::from_f64(max_next_up_next_up).is_none(),
-        "from_f64(79228162514264355185729994752f64)"
+        Decimal::from_f64(over_max).is_none(),
+        "from_f64(79_228_162_514_264_355_185_729_994_752_f64) -> none (too large)"
     );
     assert!(
-        Decimal::from_f64(max_next_up).is_none(),
-        "from_f64(79228162514264337593543950336f64)"
+        Decimal::from_f64(max_plus_one).is_none(),
+        "from_f64(79_228_162_514_264_337_593_543_950_336_f64) -> none (too large)"
     );
     assert_eq!(
         "79228162514264328797450928128",
+        Decimal::from_f64(under_max).unwrap().to_string(),
+        "from_f64(79_228_162_514_264_328_797_450_928_128_f64) -> some (inside limits)"
+    );
+    assert_eq!(
+        "79228162514264337593543950335",
         Decimal::from_f64(max).unwrap().to_string(),
-        "from_f64(79228162514264328797450928128f64)"
+        "from_f64(79_228_162_514_264_337_593_543_950_335_f64) -> some (at max)"
     );
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3137,6 +3137,19 @@ fn it_converts_from_f64_limits() {
 }
 
 #[test]
+fn it_converts_from_f64_dec_limits() {
+    use num_traits::FromPrimitive;
+
+    let max_next_up_next_up = 79228162514264355185729994752f64;
+    let max_next_up = 79228162514264337593543950336f64;
+    let max = 79228162514264328797450928128f64;
+
+    assert!(Decimal::from_f64(max_next_up_next_up).is_none(), "from_f64(79228162514264355185729994752f64)");
+    assert!(Decimal::from_f64(max_next_up).is_none(), "from_f64(79228162514264337593543950336f64)");
+    assert_eq!("79228162514264328797450928128", Decimal::from_f64(max).unwrap().to_string(), "from_f64(79228162514264328797450928128f64)");
+}
+
+#[test]
 fn it_converts_from_f64_retaining_bits() {
     let tests = [
         (0.1_f64, "0.1000000000000000055511151231"),

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3144,9 +3144,19 @@ fn it_converts_from_f64_dec_limits() {
     let max_next_up = 79228162514264337593543950336f64;
     let max = 79228162514264328797450928128f64;
 
-    assert!(Decimal::from_f64(max_next_up_next_up).is_none(), "from_f64(79228162514264355185729994752f64)");
-    assert!(Decimal::from_f64(max_next_up).is_none(), "from_f64(79228162514264337593543950336f64)");
-    assert_eq!("79228162514264328797450928128", Decimal::from_f64(max).unwrap().to_string(), "from_f64(79228162514264328797450928128f64)");
+    assert!(
+        Decimal::from_f64(max_next_up_next_up).is_none(),
+        "from_f64(79228162514264355185729994752f64)"
+    );
+    assert!(
+        Decimal::from_f64(max_next_up).is_none(),
+        "from_f64(79228162514264337593543950336f64)"
+    );
+    assert_eq!(
+        "79228162514264328797450928128",
+        Decimal::from_f64(max).unwrap().to_string(),
+        "from_f64(79228162514264328797450928128f64)"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Right now the `f64`
```
79228162514264337593543950336
```
Converts to the decimal
```
79228162514264337593543950330
```

Under `Decimal::from_f64` or `Decimal::from_f64_retain`.

Which is wrong since:
1) the float overflowed and that's not the max decimal
2) conversion to decimal should have returned `None` anyway

The root cause is losing precision when dividing by 5, leading to missing an overflow when later multiplying by 10.

The included test (specifically the middle assertion) would fail without the patch.