### PR TITLE
Add explanation of how to enable `maths` feature

### DIFF
--- a/src/maths.rs
+++ b/src/maths.rs
@@ -49,7 +49,7 @@ const FACTORIAL: [Decimal; 28] = [
 
 /// Trait exposing various mathematical operations that can be applied using a Decimal. This is only
 /// present when the `maths` feature has been enabled, e.g. by adding the crate with 
-// `cargo add rust_decimal --features maths` and importing in your Rust file with `use rust_decimal::maths::MathematicalOps;`
+// `cargo add rust_decimal --features maths` and importing in your Rust file with `use rust_decimal::MathematicalOps;`
 pub trait MathematicalOps {
     /// The estimated exponential function, e<sup>x</sup>. Stops calculating when it is within
     /// tolerance of roughly `0.0000002`.

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -48,7 +48,7 @@ const FACTORIAL: [Decimal; 28] = [
 ];
 
 /// Trait exposing various mathematical operations that can be applied using a Decimal. This is only
-/// present when the `maths` feature has been enabled, e.g. by adding the crate with 
+/// present when the `maths` feature has been enabled, e.g. by adding the crate with
 // `cargo add rust_decimal --features maths` and importing in your Rust file with `use rust_decimal::MathematicalOps;`
 pub trait MathematicalOps {
     /// The estimated exponential function, e<sup>x</sup>. Stops calculating when it is within

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -48,7 +48,8 @@ const FACTORIAL: [Decimal; 28] = [
 ];
 
 /// Trait exposing various mathematical operations that can be applied using a Decimal. This is only
-/// present when the `maths` feature has been enabled.
+/// present when the `maths` feature has been enabled, e.g. by adding the crate with 
+// `cargo add rust_decimal --features maths` and importing in your Rust file with `use rust_decimal::maths::MathematicalOps;`
 pub trait MathematicalOps {
     /// The estimated exponential function, e<sup>x</sup>. Stops calculating when it is within
     /// tolerance of roughly `0.0000002`.


### PR DESCRIPTION
Hello,
I hope you are doing well! I am relatively new to Rust, and was trying to use `MathematicalOps` from this crate (https://github.com/sourmash-bio/sourmash_plugin_branchwater/pull/458), but I could not for the life of me figure out how to "enable the `maths` feature" as mentioned in the documentation. I was finally able to see an example of how to do it after reading this PR comment: https://github.com/paupino/rust-decimal/issues/431#issuecomment-939069965

This PR adds a bit more text to the `MathematicalOps` documentation to help future users more quickly be able to use stably computed logarithms!

Warmest,
Olga