### PR TITLE
Cargo.toml:  Only enable mysql_backend on diesel, not the whole mysql feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bincode = { default-features = false, version = "1.0" }
 bytes = { default-features = false, version = "1.0" }
 criterion = { default-features = false, version = "0.5" }
 csv = "1"
+diesel = { default-features = false, features = ["mysql"], version = "2.2.3" }
 futures = { default-features = false, version = "0.3" }
 rand = { default-features = false, features = ["getrandom"], version = "0.8" }
 rand-0_9 = { default-features = false, features = ["thread_rng"], package = "rand", version = "0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ default = ["serde", "std"]
 
 borsh = ["dep:borsh", "std"]
 c-repr = [] # Force Decimal to be repr(C)
-db-diesel-mysql = ["diesel/mysql", "std"]
+db-diesel-mysql = ["diesel/mysql_backend", "std"]
 db-diesel-postgres = ["diesel/postgres", "std"]
 db-diesel2-mysql = ["db-diesel-mysql"]
 db-diesel2-postgres = ["db-diesel-postgres"]


### PR DESCRIPTION
Only the `mysql_backend` feature is required for the traits/types; `mysql` pulls in the full MySQL client machinery (including `mysqlclient-sys`, which pulls in openssl, etc)

This only benefits `diesel_async` users, as far as I can tell; `diesel_async` uses separate connection machinery (`mysql_async`, `mysql_common`), which is pure Rust and uses a more permissive license

I would guess that the same could be applied to `db-diesel-postgres`, as `diesel` does have a `postgers_backend` feature which looks like it's a similar subset of the `postgres` feature, but I couldn't test that as we're only a MySQL shop and didn't want to submit anything untested.

Note that this may be considered a breaking change.  Downstream crates/applications that pull in `rust_decimal`'s `db-diesel-mysql` feature but _not_ `diesel`'s `mysql` feature, and which need to actually connect to MySQL using `diesel`'s sync connections, are currently relying on the transitive dependency and will experience build failures.