### PR TITLE
More efficient is_zero check

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -718,8 +718,9 @@ impl Decimal {
     /// assert!(num.is_zero());
     /// ```
     #[must_use]
+    #[inline]
     pub const fn is_zero(&self) -> bool {
-        self.lo == 0 && self.mid == 0 && self.hi == 0
+        self.lo | self.mid | self.hi == 0
     }
 
     /// Returns true if this Decimal number has zero fractional part (is equal to an integer)


### PR DESCRIPTION
`rustc` is not smart enough to only use `or` for the generated assembly and adds extra instructions for jumps and compares, to facilitate the short-circuiting check. With a simple bit comparison we achieve the same effect and the compiler
does not generate any branching instructions:

https://godbolt.org/z/6nrhvsxs7