### PR TITLE
Update to bincode v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
+bincode = { default-features = false, features = ["derive"], optional = true, version = "2.0.0-rc.3" }
 
 [dev-dependencies]
 bincode = { default-features = false, version = "1.0" }
@@ -85,6 +86,7 @@ serde-with-float = ["serde"]
 serde-with-str = ["serde"]
 std = ["arrayvec/std", "borsh?/std", "bytes?/std", "rand?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
+bincode = ["dep:bincode"]
 
 [[bench]]
 harness = false

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ assert_eq!(total, dec!(27.26));
 
 **Behavior / Functionality**
 
+* bincode
 * [borsh](#borsh)
 * [c-repr](#c-repr)
 * [legacy-ops](#legacy-ops)
@@ -122,6 +123,10 @@ assert_eq!(total, dec!(27.26));
 * [serde-with-float](#serde-with-float)
 * [serde-with-str](#serde-with-str)
 * [serde-with-arbitrary-precision](#serde-with-arbitrary-precision)
+
+### `bincode`
+
+Derives `bincode::Encode` and `bincode::Decode` for `Decimal`.
 
 ### `borsh`
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -112,6 +112,7 @@ pub struct UnpackedDecimal {
     archive_attr(derive(Clone, Copy, Debug))
 )]
 #[cfg_attr(feature = "rkyv-safe", archive(check_bytes))]
+#[cfg_attr(feature = "bincode", derive(bincode::Encode, bincode::Decode))]
 pub struct Decimal {
     // Bits 0-15: unused
     // Bits 16-23: Contains "e", a value between 0-28 that indicates the scale


### PR DESCRIPTION
- [x] derive bincode::{Encode, Decode} for Decimal
- [ ] bincode v2 bumps msrv to 1.85
- [ ] tests are against bincode v1, which uses serde; i'd have to update the tests to use v2
