### PR TITLE
`postgres` -> `postgres_backend`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ bincode = { default-features = false, version = "1.0" }
 bytes = { default-features = false, version = "1.0" }
 criterion = { default-features = false, version = "0.5" }
 csv = "1"
-diesel = { default-features = false, features = ["mysql"], version = "2.2.3" }
+diesel = { default-features = false, features = ["mysql", "postgres"], version = "2.2.3" }
 futures = { default-features = false, version = "0.3" }
 rand-0_9 = { default-features = false, features = ["thread_rng"], package = "rand", version = "0.9" }
 rkyv-0_8 = { version = "0.8", package = "rkyv" }
@@ -59,7 +59,7 @@ default = ["serde", "std"]
 borsh = ["dep:borsh", "std"]
 c-repr = [] # Force Decimal to be repr(C)
 db-diesel-mysql = ["diesel/mysql_backend", "std"]
-db-diesel-postgres = ["diesel/postgres", "std"]
+db-diesel-postgres = ["diesel/postgres_backend", "std"]
 db-diesel2-mysql = ["db-diesel-mysql"]
 db-diesel2-postgres = ["db-diesel-postgres"]
 db-postgres = ["dep:bytes", "dep:postgres-types", "std"]


### PR DESCRIPTION
Analogue to #707 but for the `postgres` feature in Diesel.  
Makes stuff easier when exclusively using `diesel_async`.