### PR TITLE
Add new align16 feature to force 16 byte alignment for Decimal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ tokio-postgres = { default-features = false, version = "0.7" }
 [features]
 default = ["serde", "std"]
 
+align16 = [] # Force Decimal to be repr(align16) - the same as u128
 borsh = ["dep:borsh", "std"]
 c-repr = [] # Force Decimal to be repr(C)
 db-diesel-mysql = ["diesel/mysql_backend", "std"]

--- a/README.md
+++ b/README.md
@@ -136,13 +136,17 @@ assert_eq!(total, dec!(27.26));
 * [serde-with-str](#serde-with-str)
 * [serde-with-arbitrary-precision](#serde-with-arbitrary-precision)
 
+### `align16`
+
+Forces `Decimal`'s alignment to 16 bytes (128 bits). This is identical to `u128` and `i128`'s alignment on x86 platforms.
+
 ### `borsh`
 
 Enables [Borsh](https://borsh.io/) serialization for `Decimal`.
 
 ### `c-repr`
 
-Forces `Decimal` to use `[repr(C)]`. The corresponding target layout is 128 bit aligned.
+Forces `Decimal` to use `[repr(C)]`.
 
 ### `db-postgres`
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -101,6 +101,7 @@ pub struct UnpackedDecimal {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression), diesel(sql_type = Numeric))]
 #[cfg_attr(feature = "c-repr", repr(C))]
+#[cfg_attr(feature = "align16", repr(align(16)))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh::BorshDeserialize, borsh::BorshSerialize, borsh::BorshSchema)

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -11,6 +11,14 @@ fn layout_is_correct() {
 }
 
 #[test]
+#[cfg(feature = "align16")]
+fn align_is_correct() {
+    assert_eq!(align_of::<Decimal>(), 16);
+    assert_eq!(align_of::<Decimal>(), align_of::<u128>());
+    assert_eq!(align_of::<Decimal>(), align_of::<i128>());
+}
+
+#[test]
 fn it_can_extract_the_mantissa() {
     let tests = [
         ("1", 1i128, 0),


### PR DESCRIPTION
Fixes #649, now that the underlying alignment of 128 bit numbers has been fixed by rust.