### PR TITLE
Add `#[inline]` to `Decimal::from_parts` for performance

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -522,6 +522,7 @@ impl Decimal {
     /// let pi = Decimal::from_parts(1102470952, 185874565, 1703060790, false, 28);
     /// assert_eq!(pi.to_string(), "3.1415926535897932384626433832");
     /// ```
+    #[inline]
     #[must_use]
     pub const fn from_parts(lo: u32, mid: u32, hi: u32, negative: bool, scale: u32) -> Decimal {
         assert!(scale <= Self::MAX_SCALE, "Scale exceeds maximum supported scale");


### PR DESCRIPTION
This makes [decoding `Decimal` in `bitcode`](https://github.com/SoftbearStudios/bitcode/pull/42) 10X faster.

It works since `bitcode` checks the range of limited-range integers (like `scale`) up front, all at once, using vector instructions, and then uses `unreachable_unchecked` right before calling `Decimal::from_parts` to communicate that fact to `rustc`. This only works if `Decimal::from_parts` is inlinable.