### PR TITLE
Work towards more constant methods

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum Error {
     ErrorString(String),
     /// The value provided exceeds `Decimal::MAX`.
     ExceedsMaximumPossibleValue,
+    /// A string could not represent a scientific number.
+    FailedToParseScientificFromString,
     /// The value provided is less than `Decimal::MIN`.
     LessThanMinimumPossibleValue,
     /// An underflow is when there are more fractional digits than can be represented within `Decimal`.
@@ -20,7 +22,7 @@ pub enum Error {
     ScaleExceedsMaximumPrecision(u32),
     /// Represents a failure to convert to/from `Decimal` to the specified type. This is typically
     /// due to type constraints (e.g. `Decimal::MAX` cannot be converted into `i32`).
-    ConversionTo(String),
+    ConversionTo(&'static str),
 }
 
 impl<S> From<S> for Error
@@ -38,8 +40,7 @@ pub(crate) fn tail_error(from: &'static str) -> Result<Decimal, Error> {
     Err(from.into())
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -47,6 +48,9 @@ impl fmt::Display for Error {
             Self::ErrorString(ref err) => f.pad(err),
             Self::ExceedsMaximumPossibleValue => {
                 write!(f, "Number exceeds maximum value that can be represented.")
+            }
+            Self::FailedToParseScientificFromString => {
+                write!(f, "A string could not represent a scientific number.")
             }
             Self::LessThanMinimumPossibleValue => {
                 write!(f, "Number less than minimum value that can be represented.")

--- a/src/postgres/driver.rs
+++ b/src/postgres/driver.rs
@@ -88,7 +88,7 @@ impl<'a> FromSql<'a> for Decimal {
                 _ => "unknown special numeric",
             };
 
-            return Err(Box::new(Error::ConversionTo(special.to_string())));
+            return Err(Box::new(Error::ConversionTo(special)));
         }
 
         // Number of digits (in base 10) to print after decimal separator

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3177,7 +3177,7 @@ fn it_converts_from_f64_retaining_bits() {
 #[test]
 fn it_converts_to_integers() {
     assert_eq!(i64::try_from(Decimal::ONE), Ok(1));
-    assert_eq!(i64::try_from(Decimal::MAX), Err(Error::ConversionTo("i64".to_string())));
+    assert_eq!(i64::try_from(Decimal::MAX), Err(Error::ConversionTo("i64")));
     assert_eq!(u128::try_from(Decimal::ONE_HUNDRED), Ok(100));
 }
 


### PR DESCRIPTION
Something I didn't realize in https://github.com/paupino/rust-decimal/pull/360, `rust_decimal::Error` conflicts with CTFE (Constant Time Function Evaluator) because of the variants that use `String`.

For example, the following should be possible but isn't at the current time.

```rust
const FOO: Decimal = match Decimal::try_new(0, 0) {
    Ok(num) => num,
    Err(_) => panic!(),
};
```

```bash
destructor of `core::result::Result<decimal::Decimal, error::Error>` cannot be evaluated at compile-time
the destructor for this type cannot be evaluated in constants
```

The idea to workaround this limitation is to convert all string errors into error variants starting with the `from_scientific_exact` function. Technically a breaking change but such a thing already occurred before without a version bump.

Feel free to close this PR if desired.