### PR TITLE
Fixed issue #722 to support scientific notation in Decimal::from_str()

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1981,7 +1981,17 @@ impl FromStr for Decimal {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Decimal, Self::Err> {
-        crate::str::parse_str_radix_10(value)
+        match crate::str::parse_str_radix_10(value){
+		Ok(d) => Ok(d),
+
+		Err(e) => {
+			if value.contains('e') || value.contains("E") {
+				Decimal::from_scientific(value)
+			} else{
+				Err(e)
+			}
+		}
+	}
     }
 }
 

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -122,6 +122,18 @@ fn it_parses_big_float_string() {
 }
 
 #[test]
+fn it_parses_scientific_string(){
+    let a = Decimal::from_str("1.23e4").unwrap();
+    assert_eq!("12300", a.to_string());
+}
+
+#[test]
+fn it_parses_scientific_negative_exponent_string(){
+    let a = Decimal::from_str("6.7e-1").unwrap();
+    assert_eq!("0.67", a.to_string());
+}
+
+#[test]
 fn it_can_serialize_deserialize() {
     let tests = [
         "12.3456789",


### PR DESCRIPTION
Solving issue #722 

Implemented notation handling in the `from_str` function of `Decimal` to be able to parse through scientific or decimal notation.  It calls `from_scientific` function within `from_str`, handling both cases of notation.

Testing:
> Passed all the tests<img width="1211" height="694" alt="Screenshot 2025-10-04 001101" src="https://github.com/user-attachments/assets/825b4ba8-2750-4753-9e04-38d2481b19ad" />

> Added two test for scientific notation parsing handling <img width="1053" height="44" alt="Screenshot 2025-10-04 001110" src="https://github.com/user-attachments/assets/a8f53be2-672c-494b-9b36-a69261daa6ac" />
