### PR TITLE
Remove doc_auto_cfg and address lifetime warnings

### DIFF
--- a/macros/src/str.rs
+++ b/macros/src/str.rs
@@ -76,8 +76,8 @@ impl Display for ParseError<'_> {
     }
 }
 
-pub const fn parse_decimal(src: &str, exp: i32) -> ParseResult {
-    const fn skip_us(radix: u32, is_positive: bool, mut src: &[u8], exp: i32) -> ParseResult {
+pub const fn parse_decimal(src: &str, exp: i32) -> ParseResult<'_> {
+    const fn skip_us(radix: u32, is_positive: bool, mut src: &[u8], exp: i32) -> ParseResult<'_> {
         while let [b'_', rest @ ..] = src {
             src = rest
         }
@@ -94,7 +94,7 @@ pub const fn parse_decimal(src: &str, exp: i32) -> ParseResult {
 }
 
 // dec!() entrypoint with radix
-pub const fn parse_decimal_with_radix(src: &str, exp: i32, radix: u32) -> ParseResult {
+pub const fn parse_decimal_with_radix(src: &str, exp: i32, radix: u32) -> ParseResult<'_> {
     if 2 <= radix && radix <= 36 {
         let (is_positive, src) = parse_sign(src);
         parse_bytes(radix, is_positive, src, exp)
@@ -116,7 +116,7 @@ const fn parse_sign(src: &str) -> (bool, &[u8]) {
     }
 }
 
-const fn parse_bytes(radix: u32, is_positive: bool, src: &[u8], exp: i32) -> ParseResult {
+const fn parse_bytes(radix: u32, is_positive: bool, src: &[u8], exp: i32) -> ParseResult<'_> {
     match parse_bytes_inner(radix, src, 0) {
         (.., Some(rest)) => Err(ParseError::Unparseable(rest)),
         (_, 0, _) => Err(ParseError::Empty),
@@ -165,7 +165,7 @@ const fn to_decimal<'src>(is_positive: bool, mut num: i128, mut exp: i32) -> Par
 }
 
 // parse normal (radix 10) numbers with optional float-like .fraction and 10’s exponent
-const fn parse_10(is_positive: bool, src: &[u8], mut exp: i32) -> ParseResult {
+const fn parse_10(is_positive: bool, src: &[u8], mut exp: i32) -> ParseResult<'_> {
     // parse 1st part (upto optional . or e)
     let (mut num, len, mut more) = parse_bytes_inner(10, src, 0);
     // Numbers can’t be empty (before optional . or e)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 extern crate alloc;
 
 mod constants;


### PR DESCRIPTION
Removing `doc_auto_cfg` since it is now merged into `doc_cfg`