### PR TITLE
Support `no-std::no-alloc`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,9 @@ jobs:
         env:
           CI_DECIMAL_TEST_TARGET: ${{ matrix.target }}
 
+      - name: Check no_alloc build
+        run: cargo make test-no-alloc
+
       - name: Run default tests
         run: cargo make test-default
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Paul Mason <paul@form1.co.nz>"]
 build = "build.rs"
-categories = ["science", "mathematics", "data-structures"]
+categories = ["science", "mathematics", "data-structures", "no-std", "no-std::no-alloc"]
 description = "Decimal number implementation written in pure Rust suitable for financial and fixed-precision calculations."
 documentation = "https://docs.rs/rust_decimal/"
 edition = "2024"
@@ -55,9 +55,10 @@ version-sync = { default-features = false, features = ["html_root_url_updated", 
 rust_decimal = { path = ".", features = ["rand-0_9", "macros", "rocket-0_5-traits"] }
 
 [features]
-default = ["serde", "std"]
+default = ["alloc", "serde", "std"]
 
 align16 = [] # Force Decimal to be repr(align16) - the same as u128
+alloc = []
 borsh = ["dep:borsh", "std"]
 c-repr = [] # Force Decimal to be repr(C)
 db-diesel-mysql = ["diesel/mysql_backend", "std"]
@@ -67,14 +68,14 @@ db-diesel2-postgres = ["db-diesel-postgres"]
 db-postgres = ["dep:bytes", "dep:postgres-types", "std"]
 db-tokio-postgres = ["dep:bytes", "dep:postgres-types", "std"]
 macros = ["dep:rust_decimal_macros"]
-maths = []
+maths = ["alloc"]
 maths-nopanic = ["maths"]
 ndarray-0_16 = ["dep:ndarray-0_16"]
 proptest = ["dep:proptest"]
 rand-0_9 = ["dep:rand-0_9"]
 rocket-0_5-traits = ["dep:rocket", "std"]
 rust-fuzz = ["dep:arbitrary"]
-serde = ["dep:serde"]
+serde = ["dep:serde", "alloc"]
 serde-arbitrary-precision = ["serde-with-arbitrary-precision"]
 serde-bincode = ["serde-str"] # Backwards compatability
 serde-float = ["serde-with-float"]
@@ -82,7 +83,7 @@ serde-str = ["serde-with-str"]
 serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std", "zmij"]
 serde-with-float = ["serde"]
 serde-with-str = ["serde"]
-std = ["arrayvec/std", "borsh?/std", "bytes?/std", "rand-0_9?/std", "serde?/std", "serde_json?/std"]
+std = ["alloc", "arrayvec/std", "borsh?/std", "bytes?/std", "rand-0_9?/std", "serde?/std", "serde_json?/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ assert_eq!(total, dec!(27.26));
 
 **Behavior / Functionality**
 
+* [alloc](#alloc)
 * [borsh](#borsh)
 * [c-repr](#c-repr)
 * [macros](#macros)
@@ -154,6 +155,14 @@ assert_eq!(total, dec!(27.26));
 ### `align16`
 
 Forces `Decimal`'s alignment to 16 bytes (128 bits). This is identical to `u128` and `i128`'s alignment on x86 platforms.
+
+### `alloc`
+
+Enables features that require heap allocation via the [`alloc`](https://doc.rust-lang.org/alloc/) crate, without
+requiring `std`. Suitable for `no_std` environments that have an allocator available.
+
+Currently this gates the `LowerExp` / `UpperExp` (scientific notation) `Display` implementations. Enabled by default.
+Implied by `std`.
 
 ### `borsh`
 
@@ -392,9 +401,17 @@ Please see the `examples` directory for more information regarding `serde_json` 
 
 ### `std`
 
-Enable `std` library support. This is enabled by default, however in the future will be opt in. For now, to
-support `no_std`
-libraries, this crate can be compiled with `--no-default-features`.
+Enables `std` library support. This is enabled by default and implies `alloc`.
+
+This crate supports three build configurations:
+
+| Configuration            | Cargo flags                                  |
+|--------------------------|----------------------------------------------|
+| `std` (default)          | (default)                                    |
+| `no_std` + `alloc`       | `--no-default-features --features=alloc`     |
+| `no_std` + no allocator  | `--no-default-features`                      |
+
+The no-allocator configuration is suitable for bare-metal targets such as `x86_64-unknown-none`.
 
 ## Building
 

--- a/make/tests/misc.toml
+++ b/make/tests/misc.toml
@@ -1,11 +1,16 @@
 [tasks.test-misc]
 dependencies = [
+    "test-no-alloc",
     "test-proptest",
     "test-rust-fuzz",
     "test-rocket-traits",
     "test-borsh",
     "test-rand"
 ]
+
+[tasks.test-no-alloc]
+command = "cargo"
+args = ["build", "--no-default-features"]
 
 [tasks.test-proptest]
 command = "cargo"

--- a/make/tests/misc.toml
+++ b/make/tests/misc.toml
@@ -9,8 +9,13 @@ dependencies = [
 ]
 
 [tasks.test-no-alloc]
+dependencies = ["install-no-alloc-target"]
 command = "cargo"
-args = ["build", "--no-default-features"]
+args = ["build", "--no-default-features", "--target", "x86_64-unknown-none"]
+
+[tasks.install-no-alloc-target]
+command = "rustup"
+args = ["target", "add", "x86_64-unknown-none"]
 
 [tasks.test-proptest]
 command = "cargo"

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -567,24 +567,20 @@ impl Decimal {
     pub fn from_scientific_exact(value: &str) -> crate::Result<Decimal> {
         let mut split = value.splitn(2, ['e', 'E']);
 
-        let base = split.next().ok_or(crate::Error::FailedToParseScientificFromString)?;
-        let exp = split.next().ok_or(crate::Error::FailedToParseScientificFromString)?;
+        let base = split.next().ok_or(crate::Error::ScientificBaseNotFound)?;
+        let exp = split.next().ok_or(crate::Error::ScientificExpNotFound)?;
 
         let mut ret = Decimal::from_str(base)?;
         let current_scale = ret.scale();
 
         if let Some(stripped) = exp.strip_prefix('-') {
-            let exp: u32 = stripped
-                .parse()
-                .map_err(|_err| crate::Error::FailedToParseScientificFromString)?;
+            let exp: u32 = stripped.parse().map_err(|_err| crate::Error::ScientificExpNotFound)?;
             if exp > Self::MAX_SCALE {
                 return Err(Error::ScaleExceedsMaximumPrecision(exp));
             }
             ret.set_scale(current_scale + exp)?;
         } else {
-            let exp: u32 = exp
-                .parse()
-                .map_err(|_err| crate::Error::FailedToParseScientificFromString)?;
+            let exp: u32 = exp.parse().map_err(|_err| crate::Error::ScientificExpNotFound)?;
             if exp <= current_scale {
                 ret.set_scale(current_scale - exp)?;
             } else if exp > 0 {
@@ -660,20 +656,14 @@ impl Decimal {
     pub fn from_scientific_lossy(value: &str) -> Result<Decimal, Error> {
         let mut split = value.splitn(2, ['e', 'E']);
 
-        let base = split
-            .next()
-            .ok_or_else(|| Error::from(crate::Error::FailedToParseScientificFromString))?;
-        let exp = split
-            .next()
-            .ok_or_else(|| Error::from(crate::Error::FailedToParseScientificFromString))?;
+        let base = split.next().ok_or(Error::ScientificBaseNotFound)?;
+        let exp = split.next().ok_or(Error::ScientificExpNotFound)?;
 
         let mut ret = Decimal::from_str(base)?;
         let current_scale = ret.scale();
 
         if let Some(stripped) = exp.strip_prefix('-') {
-            let exp: u32 = stripped
-                .parse()
-                .map_err(|_| Error::from(crate::Error::FailedToParseScientificFromString))?;
+            let exp: u32 = stripped.parse().map_err(|_| Error::ScientificExpNotFound)?;
             if exp > Self::MAX_SCALE {
                 return Err(Error::ScaleExceedsMaximumPrecision(exp));
             }
@@ -684,9 +674,7 @@ impl Decimal {
                 ret.set_scale(current_scale + exp)?;
             }
         } else {
-            let exp: u32 = exp
-                .parse()
-                .map_err(|_| Error::from(crate::Error::FailedToParseScientificFromString))?;
+            let exp: u32 = exp.parse().map_err(|_| Error::ScientificExpNotFound)?;
             if exp <= current_scale {
                 ret.set_scale(current_scale - exp)?;
             } else if exp > 0 {
@@ -2439,7 +2427,16 @@ impl fmt::Display for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         let (rep, additional) = crate::str::to_str_internal(self, false, f.precision());
         if let Some(additional) = additional {
-            let value = [rep.as_str(), "0".repeat(additional).as_str()].concat();
+            // Use a stack buffer to avoid heap allocation.
+            // Decimal has a max scale of 28 and max 96-bit integer (29 digits), so the
+            // representation is at most ~32 chars + 28 zeros = 60 bytes. 64 is sufficient.
+            let mut value = arrayvec::ArrayString::<64>::new();
+            let _ = value.try_push_str(rep.as_str());
+            for _ in 0..additional {
+                if value.try_push('0').is_err() {
+                    break;
+                }
+            }
             f.pad_integral(self.is_sign_positive(), "", value.as_str())
         } else {
             f.pad_integral(self.is_sign_positive(), "", rep.as_str())
@@ -2453,12 +2450,14 @@ impl fmt::Debug for Decimal {
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl fmt::LowerExp for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::str::fmt_scientific_notation(self, "e", f)
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 impl fmt::UpperExp for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::str::fmt_scientific_notation(self, "E", f)

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1464,10 +1464,8 @@ impl Decimal {
         match strategy {
             RoundingStrategy::MidpointNearestEven => {
                 match order {
-                    Ordering::Equal => {
-                        if (value[0] & 1) == 1 {
-                            ops::array::add_one_internal(&mut value);
-                        }
+                    Ordering::Equal if (value[0] & 1) == 1 => {
+                        ops::array::add_one_internal(&mut value);
                     }
                     Ordering::Greater => {
                         // Doesn't matter about the decimal portion

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2450,14 +2450,14 @@ impl fmt::Debug for Decimal {
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "std"))]
+#[cfg(feature = "alloc")]
 impl fmt::LowerExp for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::str::fmt_scientific_notation(self, "e", f)
     }
 }
 
-#[cfg(any(feature = "alloc", feature = "std"))]
+#[cfg(feature = "alloc")]
 impl fmt::UpperExp for Decimal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         crate::str::fmt_scientific_notation(self, "E", f)

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,8 +13,6 @@ pub enum Error {
     EmptyData,
     /// The value provided exceeds `Decimal::MAX`.
     ExceedsMaximumPossibleValue,
-    /// A string could not represent a scientific number.
-    FailedToParseScientificFromString,
     /// A character could not represent a Decimal instance
     InvalidCharacter,
     /// The string must start with a digit, `+` or `-`.
@@ -29,6 +27,10 @@ pub enum Error {
     Underflow,
     /// The radix is not supported. Must be between 2 and 36.
     UnsupportedRadix,
+    /// Base wasn't present while parsing scientific notation.
+    ScientificBaseNotFound,
+    /// Exponent wasn't present while parsing scientific notation.
+    ScientificExpNotFound,
 }
 
 #[cold]
@@ -52,9 +54,6 @@ impl fmt::Display for Error {
             }
             Self::ExceedsMaximumPossibleValue => {
                 write!(f, "Number exceeds maximum value that can be represented.")
-            }
-            Self::FailedToParseScientificFromString => {
-                write!(f, "A string could not represent a scientific number.")
             }
             Self::InvalidCharacter => {
                 write!(f, "A character could not represent a Decimal instance.")
@@ -80,6 +79,12 @@ impl fmt::Display for Error {
             }
             Self::UnsupportedRadix => {
                 write!(f, "The radix is not supported. Must be between 2 and 36.")
+            }
+            Self::ScientificBaseNotFound => {
+                f.write_str("Base value was not found while attempting to parse from scientific notation.")
+            }
+            Self::ScientificExpNotFound => {
+                f.write_str("Exponent was not found while attempting to parse from scientific notation.")
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,7 +50,10 @@ impl fmt::Display for Error {
                 write!(f, "The decimal string contained more than one decimal point.")
             }
             Self::EmptyData => {
-                write!(f, "Could not represent a Decimal instance because there is no data left.")
+                write!(
+                    f,
+                    "Could not represent a Decimal instance because there is no data left."
+                )
             }
             Self::ExceedsMaximumPossibleValue => {
                 write!(f, "Number exceeds maximum value that can be represented.")

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,18 +4,18 @@ use core::fmt;
 /// Error type for the library.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
-    /// Represents a failure to convert to/from `Decimal` to the specified type. This is typically
+    /// Failed to convert to or from `Decimal` for the specified type. This is typically
     /// due to type constraints (e.g. `Decimal::MAX` cannot be converted into `i32`).
     ConversionTo(&'static str),
     /// The decimal string contained more than one decimal point.
     DuplicatedDecimalPoint,
-    /// Could not represent a Decimal instance because there no data left.
+    /// The input was empty.
     EmptyData,
     /// The value provided exceeds `Decimal::MAX`.
     ExceedsMaximumPossibleValue,
-    /// A character could not represent a Decimal instance
+    /// The input contained an invalid character.
     InvalidCharacter,
-    /// The string must start with a digit, `+` or `-`.
+    /// The string must start with a digit, `+`, or `-`.
     InvalidLeadingChar,
     /// The value provided is less than `Decimal::MIN`.
     LessThanMinimumPossibleValue,
@@ -23,13 +23,13 @@ pub enum Error {
     NoDigits,
     /// The scale provided exceeds the maximum scale that `Decimal` can represent.
     ScaleExceedsMaximumPrecision(u32),
-    /// An underflow is when there are more fractional digits than can be represented within `Decimal`.
+    /// More fractional digits were provided than `Decimal` can represent.
     Underflow,
     /// The radix is not supported. Must be between 2 and 36.
     UnsupportedRadix,
-    /// Base wasn't present while parsing scientific notation.
+    /// The base was not present while parsing scientific notation.
     ScientificBaseNotFound,
-    /// Exponent wasn't present while parsing scientific notation.
+    /// The exponent was not present while parsing scientific notation.
     ScientificExpNotFound,
 }
 
@@ -50,7 +50,7 @@ impl fmt::Display for Error {
                 write!(f, "The decimal string contained more than one decimal point.")
             }
             Self::EmptyData => {
-                write!(f, "Could not represent a Decimal instance because there no data left.")
+                write!(f, "Could not represent a Decimal instance because there is no data left.")
             }
             Self::ExceedsMaximumPossibleValue => {
                 write!(f, "Number exceeds maximum value that can be represented.")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#[cfg(any(feature = "alloc", feature = "std"))]
 extern crate alloc;
 
 mod constants;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#[cfg(any(feature = "alloc", feature = "std"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 mod constants;

--- a/src/maths.rs
+++ b/src/maths.rs
@@ -615,7 +615,7 @@ impl Pow<f64> for Decimal {
 mod test {
     use super::*;
 
-    #[cfg(not(feature = "std"))]
+    #[cfg(all(not(feature = "std"), feature = "alloc"))]
     use alloc::string::ToString;
 
     #[test]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,4 +1,5 @@
 use crate::Decimal;
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
 use alloc::string::ToString;
 use core::{fmt, str::FromStr};
 use num_traits::FromPrimitive;

--- a/src/str.rs
+++ b/src/str.rs
@@ -7,8 +7,8 @@ use crate::{
 
 use arrayvec::{ArrayString, ArrayVec};
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 use alloc::{string::String, vec::Vec};
-use core::fmt;
 
 // impl that doesn't allocate for serialization purposes.
 pub(crate) fn to_str_internal(
@@ -76,12 +76,13 @@ pub(crate) fn to_str_internal(
     (rep, additional)
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 pub(crate) fn fmt_scientific_notation(
     value: &Decimal,
     exponent_symbol: &str,
-    f: &mut fmt::Formatter<'_>,
-) -> fmt::Result {
-    #[cfg(not(feature = "std"))]
+    f: &mut core::fmt::Formatter<'_>,
+) -> core::fmt::Result {
+    #[cfg(all(not(feature = "std"), feature = "alloc"))]
     use alloc::string::ToString;
 
     // Get the scale - this is the e value. With multiples of 10 this may get bigger.

--- a/src/str.rs
+++ b/src/str.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use arrayvec::{ArrayString, ArrayVec};
 
-#[cfg(any(feature = "alloc", feature = "std"))]
+#[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};
 
 // impl that doesn't allocate for serialization purposes.
@@ -76,7 +76,7 @@ pub(crate) fn to_str_internal(
     (rep, additional)
 }
 
-#[cfg(any(feature = "alloc", feature = "std"))]
+#[cfg(feature = "alloc")]
 pub(crate) fn fmt_scientific_notation(
     value: &Decimal,
     exponent_symbol: &str,

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -383,6 +383,7 @@ fn it_formats_int() {
     assert_eq!(format!("{a:0<10.2}"), "5.00000000");
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn it_formats_lower_exp() {
     let tests = [
@@ -398,6 +399,7 @@ fn it_formats_lower_exp() {
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn it_formats_lower_exp_padding() {
     let tests = [
@@ -413,6 +415,7 @@ fn it_formats_lower_exp_padding() {
     }
 }
 
+#[cfg(any(feature = "alloc", feature = "std"))]
 #[test]
 fn it_formats_scientific_precision() {
     for (num, scale, expected_no_precision, expected_precision) in [


### PR DESCRIPTION
This isn't tested since my Mac has low storage. But here's a little peek into how `no-alloc` support could be done.

Thanks for the great crate! :)

## Context

I want to use the `rust_decimal` crate in my own library, but the lack of `core-only` support is a blocker to something I want to do.

## Checklist

- [x] Add test crate with the following setup:
	- Depend on `rust_decimal` in Cargo.toml
	- Have a veeery basic `lib.rs` and `pub fn t() -> Decimal { /* ... */ }`
	- Build with: `cargo +nightly build --no-default-features -Z build-std=core --target x86_64-unknown-none`
		- Need to pin the Nightly
- [x] Document `no_std` + `core`-only compatibility in `README.md`
- [x] Make block comments in `error.rs` look consistent (and maybe even readable)
- [x] Fix "system dependency required" tests expecting stringy errors

## Unrelated

A couple more suggestions before 2.0:

- Move all the integrations into `src/integrations/(...).rs` files
	- You can re-export them in `lib.rs` if you'd like to maintain the same API surface
		- `mod integrations; pub use integrations::*;`
	- But, as-is, it's difficult to focus on the primary logic files in the crate
- Rename `Error` to `DecimalError` 
	- Per Clippy: https://rust-lang.github.io/rust-clippy/master/index.html#error_impl_error