### PR TITLE
Allow the usage of stack-based strings

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -795,7 +795,7 @@ impl Decimal {
     /// # use rust_decimal::Error;
     /// #
     /// # fn main() -> Result<(), rust_decimal::Error> {
-    /// assert_eq!(Decimal::from_str_exact("0.001")?.array_string().as_str(), "0.001");
+    /// assert_eq!(Decimal::from_str_exact("0.001")?.array_string().as_ref(), "0.001");
     /// #     Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
`ToString::to_string` makes a heap allocation and such a thing can cause a negative performance impact if used in a hot path. For example:

```rust
fn foo(dec: &mut Decimal) {
  loop {
    // stuff
    let string = dec.to_string();
    // more stuff
  }
}
```

One of the reasons why serialization was slow was also due to two heap allocations (https://github.com/paupino/rust-decimal/pull/296). Therefore, it would be nice to expose `to_str_internal`.

The only pseudo-disadvantage is hard coding `arrayvec` into public interfaces but this can be mitigated in the future with a custom home-made `ArrayString` that returns `([u8; MAX_STR_BUFFER_SIZE], u8)`.