### PR TITLE
Fix: RUSTSEC-2026-0001

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ postgres-types = { default-features = false, optional = true, version = "0.2" }
 proptest = { default-features = false, optional = true, features = ["std"], version = "1.0" }
 rand-0_9 = { default-features = false, optional = true, package = "rand", version = "0.9" }
 rust_decimal_macros = { path = "macros", default-features = false, optional = true, version = "1" }
-#rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.46" }
+rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.46" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }


### PR DESCRIPTION
Bumped `rykv` to `0.7.46` to fix [RUSTSEC-2026-0001](https://rustsec.org/advisories/RUSTSEC-2026-0001), and `0.8.13`, even though it's dev deps only.

```bash
Crate:     rkyv
Version:   0.7.45
Title:     Potential Undefined Behaviors in `Arc<T>`/`Rc<T>` impls of `from_value` on OOM
Date:      2026-01-05
ID:        RUSTSEC-2026-0001
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0001
Solution:  Upgrade to >=0.7.46, <0.8.0 OR >=0.8.13
```