### PR TITLE
Fix: RUSTSEC-2026-0001

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ proptest = { default-features = false, optional = true, features = ["std"], vers
 rand = { default-features = false, optional = true, version = "0.8" }
 rand-0_9 = { default-features = false, optional = true, package = "rand", version = "0.9" }
 rust_decimal_macros = { path = "macros", default-features = false, optional = true, version = "1" }
-rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.42" }
+rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.46" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
 ryu = { default-features = false, optional = true, version = "1.0" }
 serde = { default-features = false, optional = true, version = "1.0" }
@@ -47,7 +47,7 @@ diesel = { default-features = false, features = ["mysql", "postgres"], version =
 futures = { default-features = false, version = "0.3" }
 rand = { default-features = false, features = ["getrandom"], version = "0.8" }
 rand-0_9 = { default-features = false, features = ["thread_rng"], package = "rand", version = "0.9" }
-rkyv-0_8 = { version = "0.8", package = "rkyv" }
+rkyv-0_8 = { version = "0.8.13", package = "rkyv" }
 rust_decimal_macros = { path = "macros" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"


### PR DESCRIPTION
Porting `rkyv` fix to `v1` branch. Original PR: https://github.com/paupino/rust-decimal/pull/769