### PR TITLE
Fix float to string loss of precision in serde arbitrary precision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ rand-0_9 = { default-features = false, optional = true, package = "rand", versio
 rust_decimal_macros = { path = "macros", default-features = false, optional = true, version = "1" }
 rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.46" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
+zmij = { default-features = false, optional = true, version = "1.0" }
 serde = { default-features = false, optional = true, version = "1.0" }
 serde_json = { default-features = false, optional = true, version = "1.0" }
 tokio-postgres = { default-features = false, optional = true, version = "0.7" }
@@ -80,7 +81,7 @@ serde-arbitrary-precision = ["serde-with-arbitrary-precision"]
 serde-bincode = ["serde-str"] # Backwards compatability
 serde-float = ["serde-with-float"]
 serde-str = ["serde-with-str"]
-serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std"]
+serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std", "zmij"]
 serde-with-float = ["serde"]
 serde-with-str = ["serde"]
 std = ["arrayvec/std", "borsh?/std", "bytes?/std", "rand-0_9?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -339,11 +339,21 @@ impl<'de> serde::de::Visitor<'de> for DecimalVisitor {
         }
     }
 
+    #[cfg(not(feature = "serde-with-arbitrary-precision"))]
     fn visit_f64<E>(self, value: f64) -> Result<Decimal, E>
     where
         E: serde::de::Error,
     {
         Decimal::from_str(&value.to_string()).map_err(|_| E::invalid_value(Unexpected::Float(value), &self))
+    }
+
+    #[cfg(feature = "serde-with-arbitrary-precision")]
+    fn visit_f64<E>(self, value: f64) -> Result<Decimal, E>
+    where
+        E: serde::de::Error,
+    {
+        Decimal::from_str(zmij::Buffer::new().format_finite(value))
+            .map_err(|_| E::invalid_value(Unexpected::Float(value), &self))
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Decimal, E>
@@ -644,6 +654,33 @@ mod test {
         assert_eq!("{\"amount\":4.81}", serialized);
         let deserialized: Record = serde_json::from_str(&serialized).unwrap();
         assert_eq!(record.amount, deserialized.amount);
+    }
+
+    #[test]
+    #[cfg(all(feature = "serde-float", feature = "serde-arbitrary-precision"))]
+    fn serialize_whole_number_decimal() {
+        let data = [
+            ("0", "0"),
+            ("1.0", "1.0"),
+            ("0.00", "0.00"),
+            ("1.234", "1.234"),
+            ("3.14159", "3.14159"),
+            ("-3.14159", "-3.14159"),
+            ("1234567890123.4567890", "1234567890123.4567890"),
+            ("-1234567890123.4567890", "-1234567890123.4567890"),
+        ];
+
+        for &(value, expected) in data.iter() {
+            let record = Record {
+                amount: Decimal::from_str(value).unwrap(),
+            };
+
+            let serialized = serde_json::to_string(&record).unwrap();
+            let value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+            let deserialized: Record = serde_json::from_value(value).unwrap();
+
+            assert_eq!(expected, deserialized.amount.to_string());
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes precision loss during float deserialization in serde arbitrary precision mode
- Uses zmij for floating-point to string conversion, following serde_json: https://github.com/serde-rs/json/pull/1304

## Related
- Port of https://github.com/paupino/rust-decimal/pull/761 to master