### PR TITLE
fix: scientific formatting of 0

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2712,4 +2712,10 @@ mod tests {
     } else {
         panic!()
     };
+
+    #[test]
+    fn from_scientific_0e0() {
+        let dec = Decimal::from_scientific_exact("0e0").unwrap();
+        assert_eq!(dec, Decimal::ZERO);
+    }
 }

--- a/src/str.rs
+++ b/src/str.rs
@@ -84,6 +84,10 @@ pub(crate) fn fmt_scientific_notation(
     #[cfg(not(feature = "std"))]
     use alloc::string::ToString;
 
+    if value.is_zero() {
+        return f.write_str("0e0");
+    }
+
     // Get the scale - this is the e value. With multiples of 10 this may get bigger.
     let mut exponent = -(value.scale() as isize);
 
@@ -1099,5 +1103,21 @@ mod test {
             parse_str_radix_10("79_228_162_514_264_337_593_543_950_335.99999"),
             Err(crate::Error::ExceedsMaximumPossibleValue)
         );
+    }
+
+    #[test]
+    fn to_scientific_0() {
+        #[cfg(not(feature = "std"))]
+        use alloc::format;
+
+        let dec_zero = format!("{:e}", Decimal::ZERO);
+        let int_zero = format!("{:e}", 0_u32);
+        assert_eq!(dec_zero, int_zero);
+        assert_eq!(
+            Decimal::from_scientific_exact(&dec_zero)
+                .unwrap_or_else(|e| panic!("Can't parse {dec_zero} into Decimal: {e:?}")),
+            Decimal::ZERO
+        );
+        assert_eq!(dec_zero, "0e0");
     }
 }


### PR DESCRIPTION
Copy of #785, targeting `master`