### PR TITLE
feat: implement num_trait gaps Bounded, NumCast, ConstZero, ConstOne…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ wasm-bindgen = { default-features = false, version = "0.2", optional = true }
 [dev-dependencies]
 criterion = { default-features = false, version = "0.5" }
 csv = "1"
+proptest = { default-features = false, features = ["std"], version = "1.0" }
 rust_decimal_macros = { path = "macros" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytemuck_derive = { default-features = false, optional = true, version = "1.7.1"
 bytes = { default-features = false, optional = true, version = "1.0" }
 diesel = { default-features = false, optional = true, version = "2.2.3" }
 ndarray = { default-features = false, optional = true, version = "0.15.6" }
-num-traits = { default-features = false, features = ["i128"], version = "0.2" }
+num-traits = { default-features = false, features = ["i128"], version = "0.2.18" }
 postgres-types = { default-features = false, optional = true, version = "0.2" }
 proptest = { default-features = false, optional = true, features = ["std"], version = "1.0" }
 rand = { default-features = false, optional = true, version = "0.8" }

--- a/src/arithmetic_impls.rs
+++ b/src/arithmetic_impls.rs
@@ -3,7 +3,9 @@
 
 use crate::{decimal::CalculationResult, ops, Decimal};
 use core::ops::{Add, Div, Mul, Rem, Sub};
-use num_traits::{CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, CheckedSub, Inv};
+use num_traits::{
+    CheckedAdd, CheckedDiv, CheckedMul, CheckedRem, CheckedSub, Inv, SaturatingAdd, SaturatingMul, SaturatingSub,
+};
 
 // Macros and `Decimal` implementations
 
@@ -195,6 +197,27 @@ impl CheckedRem for Decimal {
     #[inline]
     fn checked_rem(&self, v: &Decimal) -> Option<Decimal> {
         Decimal::checked_rem(*self, *v)
+    }
+}
+
+impl SaturatingAdd for Decimal {
+    #[inline]
+    fn saturating_add(&self, v: &Decimal) -> Decimal {
+        Decimal::saturating_add(*self, *v)
+    }
+}
+
+impl SaturatingSub for Decimal {
+    #[inline]
+    fn saturating_sub(&self, v: &Decimal) -> Decimal {
+        Decimal::saturating_sub(*self, *v)
+    }
+}
+
+impl SaturatingMul for Decimal {
+    #[inline]
+    fn saturating_mul(&self, v: &Decimal) -> Decimal {
+        Decimal::saturating_mul(*self, *v)
     }
 }
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -20,7 +20,7 @@ use diesel::{deserialize::FromSqlRow, expression::AsExpression, sql_types::Numer
 #[allow(unused_imports)] // It's not actually dead code below, but the compiler thinks it is.
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
-use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
+use num_traits::{Bounded, ConstOne, ConstZero, FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
 #[cfg(feature = "rkyv")]
 use rkyv::{Archive, Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
@@ -2041,6 +2041,14 @@ impl One for Decimal {
     }
 }
 
+impl ConstZero for Decimal {
+    const ZERO: Self = Decimal::ZERO;
+}
+
+impl ConstOne for Decimal {
+    const ONE: Self = Decimal::ONE;
+}
+
 impl Signed for Decimal {
     fn abs(&self) -> Self {
         self.abs()
@@ -2080,6 +2088,22 @@ impl Num for Decimal {
 
     fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         Decimal::from_str_radix(str, radix)
+    }
+}
+
+impl Bounded for Decimal {
+    fn min_value() -> Self {
+        Decimal::MIN
+    }
+
+    fn max_value() -> Self {
+        Decimal::MAX
+    }
+}
+
+impl num_traits::NumCast for Decimal {
+    fn from<T: ToPrimitive>(n: T) -> Option<Self> {
+        n.to_f64().and_then(<Decimal as FromPrimitive>::from_f64)
     }
 }
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2103,7 +2103,20 @@ impl Bounded for Decimal {
 
 impl num_traits::NumCast for Decimal {
     fn from<T: ToPrimitive>(n: T) -> Option<Self> {
-        n.to_f64().and_then(<Decimal as FromPrimitive>::from_f64)
+        // f64 can only exactly represent integers up to 2^53, and Decimal::MAX
+        // exceeds f64's integer range, so funneling everything through to_f64
+        // loses precision for large integer inputs. When the source is
+        // integer-valued, prefer the wide-integer path so values like
+        // 9_007_199_254_740_993u64 or i128 values near Decimal::MAX round-trip.
+        let f = n.to_f64()?;
+        if f.is_finite() && f.fract() == 0.0 {
+            if let Some(i) = n.to_i128() {
+                return Decimal::from_i128(i);
+            }
+            // we don't need to check n.to_u128() because no value in the interval
+            // (i128::MAX, u128::MAX] is representable by Decimal.
+        }
+        Decimal::from_f64(f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ pub mod prelude {
     pub use crate::maths::MathematicalOps;
     pub use crate::{Decimal, RoundingStrategy};
     pub use core::str::FromStr;
-    pub use num_traits::{FromPrimitive, One, Signed, ToPrimitive, Zero};
+    pub use num_traits::{Bounded, FromPrimitive, One, Signed, ToPrimitive, Zero};
 }
 
 #[cfg(feature = "macros")]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -4885,7 +4885,10 @@ mod issues {
 
 mod num_traits_impls {
     use core::str::FromStr;
-    use num_traits::{Bounded, ConstOne, ConstZero, NumCast, SaturatingAdd, SaturatingMul, SaturatingSub};
+    use num_traits::{
+        Bounded, ConstOne, ConstZero, FromPrimitive, NumCast, SaturatingAdd, SaturatingMul, SaturatingSub, ToPrimitive,
+    };
+    use proptest::prelude::*;
     use rust_decimal::Decimal;
 
     #[test]
@@ -4936,6 +4939,55 @@ mod num_traits_impls {
     }
 
     #[test]
+    fn num_cast_u64_above_f64_integer_precision() {
+        // 2^53 + 1 cannot be represented exactly as an f64, so routing
+        // through to_f64 would silently round to 2^53. NumCast should
+        // preserve the integer value.
+        let n: u64 = 9_007_199_254_740_993;
+        assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_u64(n));
+    }
+
+    #[test]
+    fn num_cast_i128_near_decimal_max() {
+        // Value close to (but below) Decimal::MAX. The f64 approximation
+        // would lose enough precision to drift outside Decimal's range, so
+        // the integer path must be taken.
+        let n: i128 = 79_228_162_514_264_337_593_543_950_000;
+        assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_i128(n));
+    }
+
+    #[test]
+    fn num_cast_i128_negative_near_decimal_min() {
+        let n: i128 = -79_228_162_514_264_337_593_543_950_000;
+        assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_i128(n));
+    }
+
+    #[test]
+    fn num_cast_integer_out_of_decimal_range() {
+        // i128::MAX exceeds Decimal::MAX, so even via the integer path the
+        // result should be None rather than a rounded approximation.
+        assert_eq!(<Decimal as NumCast>::from(i128::MAX), None);
+        assert_eq!(<Decimal as NumCast>::from(i128::MIN), None);
+        assert_eq!(<Decimal as NumCast>::from(u128::MAX), None);
+    }
+
+    #[test]
+    fn num_cast_integer_valued_float() {
+        // A finite float with no fractional component should still take the
+        // float path (its source type's ToPrimitive::to_i128 yields the
+        // truncated integer, which equals the value).
+        assert_eq!(<Decimal as NumCast>::from(3.0f64), Decimal::from_i32(3));
+        assert_eq!(<Decimal as NumCast>::from(-7.0f32), Decimal::from_i32(-7));
+    }
+
+    #[test]
+    fn num_cast_extremes_of_primitive_integer_types() {
+        assert_eq!(<Decimal as NumCast>::from(i64::MAX), Decimal::from_i64(i64::MAX));
+        assert_eq!(<Decimal as NumCast>::from(i64::MIN), Decimal::from_i64(i64::MIN));
+        assert_eq!(<Decimal as NumCast>::from(u64::MAX), Decimal::from_u64(u64::MAX));
+    }
+
+    #[test]
     fn saturating_add_normal_and_overflow() {
         let a = Decimal::from_str("1.5").unwrap();
         let b = Decimal::from_str("2.5").unwrap();
@@ -4978,5 +5030,91 @@ mod num_traits_impls {
             SaturatingMul::saturating_mul(&Decimal::MIN, &Decimal::TWO),
             Decimal::MIN
         );
+    }
+
+    proptest! {
+        #[test]
+        fn num_cast_matches_from_i128(n: i128) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_i128(n));
+        }
+
+        #[test]
+        fn num_cast_matches_from_u128(n: u128) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_u128(n));
+        }
+
+        #[test]
+        fn num_cast_matches_from_i64(n: i64) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_i64(n));
+        }
+
+        #[test]
+        fn num_cast_matches_from_u64(n: u64) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_u64(n));
+        }
+
+        #[test]
+        fn num_cast_matches_from_i32(n: i32) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_i32(n));
+        }
+
+        #[test]
+        fn num_cast_matches_from_u32(n: u32) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_u32(n));
+        }
+
+        #[test]
+        fn num_cast_matches_from_f64(n: f64) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_f64(n));
+        }
+
+        // f32 cannot round-trip through Decimal::from_f32: NumCast::from is
+        // generic over ToPrimitive, which only exposes to_f64, so f32 sources
+        // are losslessly cast to f64 and then funneled through Decimal::from_f64.
+        // That preserves more digits than from_f32 would (which applies
+        // f32-precision-aware truncation). Both paths represent the same
+        // numeric value, but produce different Decimal digit counts. The
+        // contract we *can* uphold is that f32 sources match the f32-cast-to-f64
+        // conversion.
+        #[test]
+        fn num_cast_f32_matches_f64_path(n: f32) {
+            prop_assert_eq!(<Decimal as NumCast>::from(n), Decimal::from_f64(n as f64));
+        }
+    }
+
+    proptest! {
+        // The same integer value reached through different source types should
+        // produce the same Decimal. Restricted to f64's exact-integer range so
+        // the float source is also lossless; outside that range, n as f64 would
+        // round and the three paths would legitimately diverge.
+        #[test]
+        fn num_cast_consistent_across_source_types(n in -(1i64 << 53)..(1i64 << 53)) {
+            let via_i64 = <Decimal as NumCast>::from(n);
+            let via_i128 = <Decimal as NumCast>::from(n as i128);
+            let via_f64 = <Decimal as NumCast>::from(n as f64);
+            prop_assert_eq!(via_i64, via_i128);
+            prop_assert_eq!(via_i64, via_f64);
+        }
+
+        // For any i128 that NumCast accepts, converting back via ToPrimitive
+        // must recover the original value.
+        #[test]
+        fn num_cast_i128_round_trip_through_decimal(n: i128) {
+            if let Some(d) = <Decimal as NumCast>::from(n) {
+                prop_assert_eq!(d.to_i128(), Some(n));
+            }
+        }
+
+        // Ordering on the source type must be preserved by NumCast for any pair
+        // both successfully converted.
+        #[test]
+        fn num_cast_preserves_ordering_i128(a: i128, b: i128) {
+            if let (Some(da), Some(db)) = (
+                <Decimal as NumCast>::from(a),
+                <Decimal as NumCast>::from(b),
+            ) {
+                prop_assert_eq!(a.cmp(&b), da.cmp(&db));
+            }
+        }
     }
 }

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -4882,3 +4882,101 @@ mod issues {
         assert_result(29, a, b);
     }
 }
+
+mod num_traits_impls {
+    use core::str::FromStr;
+    use num_traits::{Bounded, ConstOne, ConstZero, NumCast, SaturatingAdd, SaturatingMul, SaturatingSub};
+    use rust_decimal::Decimal;
+
+    #[test]
+    fn bounded_min_max() {
+        assert_eq!(<Decimal as Bounded>::min_value(), Decimal::MIN);
+        assert_eq!(<Decimal as Bounded>::max_value(), Decimal::MAX);
+    }
+
+    #[test]
+    fn const_zero_and_one_usable_in_const_context() {
+        const Z: Decimal = <Decimal as ConstZero>::ZERO;
+        const O: Decimal = <Decimal as ConstOne>::ONE;
+        assert_eq!(Z, Decimal::ZERO);
+        assert_eq!(O, Decimal::ONE);
+    }
+
+    #[test]
+    fn bounded_in_prelude() {
+        use rust_decimal::prelude::*;
+        let _: Decimal = Bounded::min_value();
+        let _: Decimal = Bounded::max_value();
+    }
+
+    #[test]
+    fn num_cast_from_integers() {
+        assert_eq!(<Decimal as NumCast>::from(0i8), Some(Decimal::ZERO));
+        assert_eq!(<Decimal as NumCast>::from(-1i8), Some(Decimal::NEGATIVE_ONE));
+        assert_eq!(<Decimal as NumCast>::from(1i32), Some(Decimal::ONE));
+        assert_eq!(<Decimal as NumCast>::from(42u64), Decimal::from_str("42").ok());
+        assert_eq!(<Decimal as NumCast>::from(100i128), Decimal::from_str("100").ok());
+    }
+
+    #[test]
+    fn num_cast_from_floats() {
+        assert_eq!(<Decimal as NumCast>::from(0.0f32), Some(Decimal::ZERO));
+        assert_eq!(<Decimal as NumCast>::from(1.5f64), Decimal::from_str("1.5").ok());
+        assert_eq!(<Decimal as NumCast>::from(-2.25f64), Decimal::from_str("-2.25").ok());
+    }
+
+    #[test]
+    fn num_cast_rejects_non_finite_and_out_of_range() {
+        assert_eq!(<Decimal as NumCast>::from(f64::NAN), None);
+        assert_eq!(<Decimal as NumCast>::from(f64::INFINITY), None);
+        assert_eq!(<Decimal as NumCast>::from(f64::NEG_INFINITY), None);
+        // Decimal::MAX is ~7.9e28; 1e30 sits above it.
+        assert_eq!(<Decimal as NumCast>::from(1.0e30f64), None);
+        assert_eq!(<Decimal as NumCast>::from(-1.0e30f64), None);
+    }
+
+    #[test]
+    fn saturating_add_normal_and_overflow() {
+        let a = Decimal::from_str("1.5").unwrap();
+        let b = Decimal::from_str("2.5").unwrap();
+        assert_eq!(SaturatingAdd::saturating_add(&a, &b), Decimal::from_str("4.0").unwrap());
+        assert_eq!(
+            SaturatingAdd::saturating_add(&Decimal::MAX, &Decimal::ONE),
+            Decimal::MAX
+        );
+        assert_eq!(
+            SaturatingAdd::saturating_add(&Decimal::MIN, &Decimal::NEGATIVE_ONE),
+            Decimal::MIN
+        );
+    }
+
+    #[test]
+    fn saturating_sub_normal_and_overflow() {
+        let a = Decimal::from_str("5").unwrap();
+        let b = Decimal::from_str("2").unwrap();
+        assert_eq!(SaturatingSub::saturating_sub(&a, &b), Decimal::from_str("3").unwrap());
+        assert_eq!(
+            SaturatingSub::saturating_sub(&Decimal::MIN, &Decimal::ONE),
+            Decimal::MIN
+        );
+        assert_eq!(
+            SaturatingSub::saturating_sub(&Decimal::MAX, &Decimal::NEGATIVE_ONE),
+            Decimal::MAX
+        );
+    }
+
+    #[test]
+    fn saturating_mul_normal_and_overflow() {
+        let a = Decimal::from_str("3").unwrap();
+        let b = Decimal::from_str("4").unwrap();
+        assert_eq!(SaturatingMul::saturating_mul(&a, &b), Decimal::from_str("12").unwrap());
+        assert_eq!(
+            SaturatingMul::saturating_mul(&Decimal::MAX, &Decimal::TWO),
+            Decimal::MAX
+        );
+        assert_eq!(
+            SaturatingMul::saturating_mul(&Decimal::MIN, &Decimal::TWO),
+            Decimal::MIN
+        );
+    }
+}


### PR DESCRIPTION
Closes #573.

Fills a handful of `num_traits` gaps where `Decimal` already had the
underlying constants/methods but no trait impl, which forces downstream
generic code to special-case `Decimal`.

## Trait impls added

| Trait | Maps to | Location |
|---|---|---|
| `Bounded` | `Decimal::MIN` / `Decimal::MAX` | `src/decimal.rs` |
| `ConstZero` | `Decimal::ZERO` (const) | `src/decimal.rs` |
| `ConstOne` | `Decimal::ONE` (const) | `src/decimal.rs` |
| `NumCast` | `ToPrimitive::to_f64` → `Decimal::from_f64` | `src/decimal.rs` |
| `SaturatingAdd` | wraps inherent `Decimal::saturating_add` | `src/arithmetic_impls.rs` |
| `SaturatingSub` | wraps inherent `Decimal::saturating_sub` | same |
| `SaturatingMul` | wraps inherent `Decimal::saturating_mul` | same |

Also exposes `Bounded` through `rust_decimal::prelude` next to the existing
`One` / `Zero` / `Signed` re-exports. (`NumCast`/`Const*`/`Saturating*` are
typically used through generic bounds, not prelude imports — left out
intentionally.) 

This PR bumps the num_traits dependency from 0.2.0 to 0.2.18 in order to include ConstZero and ConstOne. My original plan was to leave it at 0.2.0 but after I had included the saturating operation traits I realized that they would force a bump to 0.2.12. I figured we could just include them all to see what the full changeset would look like. If you decide that you don't want to change the dependency resolution, it's trivial to strip those traits and trim the scope down to NumCast and Bounded.