### PR TITLE
Various performance improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,11 @@ harness = false
 name = "comparison"
 path = "benches/comparison.rs"
 
+[[bench]]
+harness = false
+name = "perf_ops"
+path = "benches/perf_ops.rs"
+
 [[example]]
 name = "rkyv-remote"
 required-features = ["macros"]

--- a/benches/perf_ops.rs
+++ b/benches/perf_ops.rs
@@ -1,0 +1,99 @@
+//! Micro-benchmarks targeting the operations affected by the performance work.
+//! Inputs are passed through `black_box` so the compiler cannot const-fold them.
+
+use core::hash::{Hash, Hasher};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rust_decimal::Decimal;
+
+// 64-bit mantissas (hi == 0, mid != 0) to exercise the 64-bit fast paths.
+const A_64: Decimal = Decimal::from_parts(0x1234_5678, 0x9ABC, 0, false, 6);
+const B_64: Decimal = Decimal::from_parts(0x90AB_CDEF, 0x1357, 0, false, 6);
+// Same magnitudes but different scales (exercises rescale alignment).
+const A_64_S2: Decimal = Decimal::from_parts(0x1234_5678, 0x9ABC, 0, false, 2);
+const B_64_S8: Decimal = Decimal::from_parts(0x90AB_CDEF, 0x1357, 0, false, 8);
+// 96-bit mantissa.
+const C_96: Decimal = Decimal::from_parts(0x1234_5678, 0x9ABC_DEF0, 0x1357, false, 10);
+// Same mantissa/scale as C_96 but opposite sign: identical lo/mid/hi, only flags differ. This is
+// the worst case for the equality fast path (all four field compares run, then it still falls
+// back to the full comparison).
+const C_96_NEG: Decimal = Decimal::from_parts(0x1234_5678, 0x9ABC_DEF0, 0x1357, true, 10);
+// Numerically equal values with different scales (1.5 == 1.50): different bit patterns, so the
+// fast path misses and the comparison runs.
+const EQ_15: Decimal = Decimal::from_parts(15, 0, 0, false, 1);
+const EQ_150: Decimal = Decimal::from_parts(150, 0, 0, false, 2);
+// 64-bit operands whose aligned sum exceeds 96 bits (10_000_000_000 == 0x2_540B_E400 at scale 0,
+// plus a value at scale 19): the add fast path computes the u128 result, sees it overflow 96 bits
+// and discards it, falling back to the slow path.
+const ADD_BIG: Decimal = Decimal::from_parts(0x540B_E400, 0x2, 0, false, 0);
+const ADD_SMALL_S19: Decimal = Decimal::from_parts(1, 0, 0, false, 19);
+// Even mantissa with no trailing zeros (0.00012): normalize finds nothing to strip but still has
+// to check.
+const NORM_NOSTRIP: Decimal = Decimal::from_parts(12, 0, 0, false, 5);
+// Odd mantissa (19.99): cannot have trailing zeros, exercises the odd fast path.
+const NORM_ODD: Decimal = Decimal::from_parts(1999, 0, 0, false, 2);
+
+struct NopHasher(u64);
+impl Hasher for NopHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    fn write(&mut self, bytes: &[u8]) {
+        for b in bytes {
+            self.0 = self.0.wrapping_mul(31).wrapping_add(*b as u64);
+        }
+    }
+}
+
+fn benches(c: &mut Criterion) {
+    c.bench_function("mul_64", |b| b.iter(|| black_box(A_64) * black_box(B_64)));
+    c.bench_function("mul_96", |b| b.iter(|| black_box(C_96) * black_box(B_64)));
+
+    c.bench_function("add_64_same_scale", |b| b.iter(|| black_box(A_64) + black_box(B_64)));
+    c.bench_function("add_64_diff_scale", |b| {
+        b.iter(|| black_box(A_64_S2) + black_box(B_64_S8))
+    });
+    c.bench_function("sub_64_diff_scale", |b| {
+        b.iter(|| black_box(A_64_S2) - black_box(B_64_S8))
+    });
+
+    c.bench_function("rescale_up", |b| b.iter(|| black_box(A_64).rescale(black_box(20))));
+    c.bench_function("rescale_down", |b| b.iter(|| black_box(C_96).rescale(black_box(2))));
+    c.bench_function("round_dp", |b| b.iter(|| black_box(C_96).round_dp(black_box(3))));
+    c.bench_function("trunc", |b| b.iter(|| black_box(C_96).trunc()));
+
+    // Trailing-zero heavy value for normalize/hash.
+    let trailing = Decimal::from_parts(1_000_000, 0, 0, false, 10);
+    c.bench_function("normalize", |b| b.iter(|| black_box(trailing).normalize()));
+    c.bench_function("hash", |b| {
+        b.iter(|| {
+            let mut h = NopHasher(0);
+            black_box(trailing).hash(&mut h);
+            h.finish()
+        })
+    });
+
+    c.bench_function("floor", |b| b.iter(|| black_box(C_96).floor()));
+    c.bench_function("ceil", |b| b.iter(|| black_box(C_96).ceil()));
+
+    c.bench_function("eq_equal", |b| b.iter(|| black_box(C_96) == black_box(C_96)));
+    // Differs in the first limb -> fast path rejects on the first compare, then falls to cmp.
+    c.bench_function("eq_neq_lo", |b| b.iter(|| black_box(A_64) == black_box(B_64)));
+    // Differs only in flags -> all four field compares run before falling to cmp (worst case).
+    c.bench_function("eq_neq_flags", |b| b.iter(|| black_box(C_96) == black_box(C_96_NEG)));
+    // Equal value, different scale -> fast path misses, cmp returns equal.
+    c.bench_function("eq_equal_diff_scale", |b| {
+        b.iter(|| black_box(EQ_15) == black_box(EQ_150))
+    });
+
+    // Add where the 64-bit fast path computes a result that overflows 96 bits and is discarded.
+    c.bench_function("add_64_overflow", |b| {
+        b.iter(|| black_box(ADD_BIG) + black_box(ADD_SMALL_S19))
+    });
+    // Normalize on an even mantissa that has no trailing zeros to strip.
+    c.bench_function("normalize_nostrip", |b| b.iter(|| black_box(NORM_NOSTRIP).normalize()));
+    // Normalize on an odd mantissa (hits the odd fast path).
+    c.bench_function("normalize_odd", |b| b.iter(|| black_box(NORM_ODD).normalize()));
+}
+
+criterion_group!(g, benches);
+criterion_main!(g);

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2779,6 +2779,11 @@ impl<'a> RemAssign<&'a Decimal> for &'a mut Decimal {
 impl PartialEq for Decimal {
     #[inline]
     fn eq(&self, other: &Decimal) -> bool {
+        // Identical bit patterns are always equal (same mantissa, scale and sign). This is the
+        // common case for dedup/lookup and short-circuits the full comparison.
+        if self.lo == other.lo && self.mid == other.mid && self.hi == other.hi && self.flags == other.flags {
+            return true;
+        }
         self.cmp(other) == Equal
     }
 }

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1312,9 +1312,18 @@ impl Decimal {
             return *self;
         }
 
-        // Opportunity for optimization here
-        let floored = self.trunc();
-        if self.is_sign_negative() && !self.fract().is_zero() {
+        // Truncate once, learning at the same time whether a fractional part was discarded, so we
+        // avoid recomputing the truncation (and a full subtraction) just to test for a fraction.
+        let mut working = [self.lo, self.mid, self.hi];
+        let mut working_scale = scale;
+        let had_fraction = ops::array::truncate_internal(&mut working, &mut working_scale, 0);
+        let floored = Decimal {
+            lo: working[0],
+            mid: working[1],
+            hi: working[2],
+            flags: flags(self.is_sign_negative(), working_scale),
+        };
+        if self.is_sign_negative() && had_fraction {
             floored - ONE
         } else {
             floored
@@ -1341,11 +1350,21 @@ impl Decimal {
             return *self;
         }
 
-        // Opportunity for optimization here
-        if self.is_sign_positive() && !self.fract().is_zero() {
-            self.trunc() + ONE
+        // Truncate once, learning at the same time whether a fractional part was discarded, so we
+        // avoid recomputing the truncation (and a full subtraction) just to test for a fraction.
+        let mut working = [self.lo, self.mid, self.hi];
+        let mut working_scale = scale;
+        let had_fraction = ops::array::truncate_internal(&mut working, &mut working_scale, 0);
+        let truncated = Decimal {
+            lo: working[0],
+            mid: working[1],
+            hi: working[2],
+            flags: flags(self.is_sign_negative(), working_scale),
+        };
+        if self.is_sign_positive() && had_fraction {
+            truncated + ONE
         } else {
-            self.trunc()
+            truncated
         }
     }
 

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1429,6 +1429,12 @@ impl Decimal {
             return;
         }
 
+        // An odd mantissa cannot be divisible by 10, so there are no trailing zeros to strip.
+        // This is a cheap, common early-out (every other value, and every odd-valued hash key).
+        if self.lo & 1 == 1 {
+            return;
+        }
+
         let mut result = self.mantissa_array3();
         let mut working = self.mantissa_array3();
         while scale > 0 {

--- a/src/ops/add.rs
+++ b/src/ops/add.rs
@@ -1,4 +1,7 @@
-use crate::constants::{MAX_I32_SCALE, POWERS_10, SCALE_MASK, SCALE_SHIFT, SIGN_MASK, U32_MASK, U32_MAX};
+use crate::constants::{
+    BIG_POWERS_10, MAX_I32_SCALE, MAX_I64_SCALE, OVERFLOW_U96, POWERS_10, SCALE_MASK, SCALE_SHIFT, SIGN_MASK, U32_MASK,
+    U32_MAX,
+};
 use crate::decimal::{CalculationResult, Decimal};
 use crate::ops::common::{Buf24, Dec64};
 
@@ -57,6 +60,54 @@ fn add_sub_internal(d1: &Decimal, d2: &Decimal, subtract: bool) -> CalculationRe
             }
         } else {
             return fast_add(lo1, lo2, d1.flags(), effective_subtract);
+        }
+    }
+
+    // Fast path: both operands fit in 64 bits. We can align scales and add/subtract directly in
+    // 128-bit arithmetic, committing only if the result fits within 96 bits.
+    if d1.hi() == 0 && d2.hi() == 0 {
+        let m1 = (d1.lo() as u64) | ((d1.mid() as u64) << 32);
+        let m2 = (d2.lo() as u64) | ((d2.mid() as u64) << 32);
+        // Zeros are handled by the dedicated logic below.
+        if m1 != 0 && m2 != 0 {
+            let s1 = d1.scale();
+            let s2 = d2.scale();
+            let diff = s1.abs_diff(s2);
+            // The smaller-scale operand is scaled up by 10^diff. Keeping diff within 19 ensures
+            // the widening multiply stays inside 128 bits.
+            if diff <= MAX_I64_SCALE {
+                let (a, b, scale) = if diff == 0 {
+                    (m1 as u128, m2 as u128, s1)
+                } else {
+                    let power = BIG_POWERS_10[(diff - 1) as usize] as u128;
+                    if s1 > s2 {
+                        (m1 as u128, m2 as u128 * power, s1)
+                    } else {
+                        (m1 as u128 * power, m2 as u128, s2)
+                    }
+                };
+
+                let negative = d1.is_sign_negative();
+                let (magnitude, negative) = if effective_subtract {
+                    if a >= b {
+                        (a - b, negative)
+                    } else {
+                        (b - a, !negative)
+                    }
+                } else {
+                    (a + b, negative)
+                };
+
+                if magnitude < OVERFLOW_U96 {
+                    return CalculationResult::Ok(Decimal::from_parts(
+                        magnitude as u32,
+                        (magnitude >> 32) as u32,
+                        (magnitude >> 64) as u32,
+                        negative,
+                        scale,
+                    ));
+                }
+            }
         }
     }
 

--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -20,23 +20,30 @@ fn rescale<const ROUND: bool>(value: &mut [u32; 3], value_scale: &mut u32, new_s
     }
 
     if *value_scale > new_scale {
-        let mut diff = value_scale.wrapping_sub(new_scale);
-        // Scaling further isn't possible since we got an overflow
-        // In this case we need to reduce the accuracy of the "side to keep"
-
-        // Now do the necessary rounding
-        let mut remainder = 0;
-        while let Some(diff_minus_one) = diff.checked_sub(1) {
+        // We need to drop `diff` digits. Every dropped digit except the most significant one is
+        // discarded; only that most significant dropped digit determines rounding. The lower
+        // `diff - 1` digits are dropped in chunks of up to 9 (a single `u32` division each) and
+        // the final digit is then isolated with a single divide by 10, so the result is identical
+        // to dropping one digit at a time.
+        let diff = value_scale.wrapping_sub(new_scale);
+        let mut to_drop = diff - 1;
+        while to_drop > 0 {
             if is_all_zero(value) {
                 *value_scale = new_scale;
                 return;
             }
-
-            diff = diff_minus_one;
-
-            // Any remainder is discarded if diff > 0 still (i.e. lost precision)
-            remainder = div_by_u32(value, 10);
+            let chunk = to_drop.min(9);
+            div_by_u32(value, POWERS_10[chunk as usize]);
+            to_drop -= chunk;
         }
+
+        if is_all_zero(value) {
+            *value_scale = new_scale;
+            return;
+        }
+
+        // Now do the necessary rounding based on the most significant dropped digit.
+        let mut remainder = div_by_u32(value, 10);
         if ROUND && remainder >= 5 {
             for part in value.iter_mut() {
                 let digit = u64::from(*part) + 1u64;
@@ -49,12 +56,21 @@ fn rescale<const ROUND: bool>(value: &mut [u32; 3], value_scale: &mut u32, new_s
         }
         *value_scale = new_scale;
     } else {
+        // Scale up by multiplying by powers of 10, in chunks of up to 9 while they fit within 96
+        // bits. Once a chunk would overflow we fall back to multiplying one digit at a time so we
+        // still apply the maximum number of multiplications that fit.
         let mut diff = new_scale.wrapping_sub(*value_scale);
         let mut working = [value[0], value[1], value[2]];
-        while let Some(diff_minus_one) = diff.checked_sub(1) {
-            if mul_by_10(&mut working) == 0 {
+        while diff > 0 {
+            let chunk = diff.min(9);
+            let mut trial = working;
+            if chunk > 1 && mul_by_u32(&mut trial, POWERS_10[chunk as usize]) == 0 {
+                working = trial;
                 value.copy_from_slice(&working);
-                diff = diff_minus_one;
+                diff -= chunk;
+            } else if mul_by_10(&mut working) == 0 {
+                value.copy_from_slice(&working);
+                diff -= 1;
             } else {
                 break;
             }
@@ -346,6 +362,31 @@ mod test {
                 value_scale, expected_scale,
                 "value: {value_raw}, requested scale: {new_scale}"
             );
+        }
+    }
+
+    #[test]
+    fn it_rounds_at_the_half_boundary_when_scaling_down() {
+        // Scale differences greater than 9 exercise the chunked scale-down path. Rounding must
+        // still be driven solely by the most significant dropped digit (round half away from zero
+        // for the default rescale), regardless of how the dropped digits are chunked.
+        let tests = &[
+            // value, new_scale, expected rounded value, expected scale
+            ("0.5", 0, "1", 0),
+            ("0.45", 1, "0.5", 1),
+            ("0.4999999999", 0, "0", 0),           // first dropped digit is 4 -> no round up
+            ("0.5000000001", 0, "1", 0),           // first dropped digit is 5 -> round up
+            ("1.50000000000000000000", 0, "2", 0), // diff = 20, chunked
+            ("1.49999999999999999999", 0, "1", 0), // diff = 20, chunked, no round
+            ("2.55000000000000000000", 1, "2.6", 1),
+            ("0.00000000005", 0, "0", 0),
+        ];
+        for &(value_raw, new_scale, expected_value, expected_scale) in tests {
+            let (expected_value, _) = to_mantissa_array_with_scale(expected_value);
+            let (mut value, mut value_scale) = to_mantissa_array_with_scale(value_raw);
+            rescale_internal(&mut value, &mut value_scale, new_scale);
+            assert_eq!(value, expected_value, "value: {value_raw} -> scale {new_scale}");
+            assert_eq!(value_scale, expected_scale, "value: {value_raw} -> scale {new_scale}");
         }
     }
 

--- a/src/ops/array.rs
+++ b/src/ops/array.rs
@@ -7,16 +7,25 @@ pub(crate) fn rescale_internal(value: &mut [u32; 3], value_scale: &mut u32, new_
     rescale::<true>(value, value_scale, new_scale);
 }
 
+/// Rescales as `rescale_internal` but without rounding, returning whether any nonzero digit was
+/// discarded (i.e. whether the value had a fractional part relative to `desired_scale`).
+#[inline]
+pub(crate) fn truncate_internal(value: &mut [u32; 3], value_scale: &mut u32, desired_scale: u32) -> bool {
+    rescale::<false>(value, value_scale, desired_scale)
+}
+
+// Returns whether any nonzero digit was discarded while scaling down (always false when scaling up
+// or when there is nothing to do).
 #[inline(always)]
-fn rescale<const ROUND: bool>(value: &mut [u32; 3], value_scale: &mut u32, new_scale: u32) {
+fn rescale<const ROUND: bool>(value: &mut [u32; 3], value_scale: &mut u32, new_scale: u32) -> bool {
     if *value_scale == new_scale {
         // Nothing to do
-        return;
+        return false;
     }
 
     if is_all_zero(value) {
         *value_scale = new_scale.min(MAX_SCALE_U32);
-        return;
+        return false;
     }
 
     if *value_scale > new_scale {
@@ -26,24 +35,26 @@ fn rescale<const ROUND: bool>(value: &mut [u32; 3], value_scale: &mut u32, new_s
         // the final digit is then isolated with a single divide by 10, so the result is identical
         // to dropping one digit at a time.
         let diff = value_scale.wrapping_sub(new_scale);
+        let mut discarded = false;
         let mut to_drop = diff - 1;
         while to_drop > 0 {
             if is_all_zero(value) {
                 *value_scale = new_scale;
-                return;
+                return discarded;
             }
             let chunk = to_drop.min(9);
-            div_by_u32(value, POWERS_10[chunk as usize]);
+            discarded |= div_by_u32(value, POWERS_10[chunk as usize]) != 0;
             to_drop -= chunk;
         }
 
         if is_all_zero(value) {
             *value_scale = new_scale;
-            return;
+            return discarded;
         }
 
         // Now do the necessary rounding based on the most significant dropped digit.
         let mut remainder = div_by_u32(value, 10);
+        discarded |= remainder != 0;
         if ROUND && remainder >= 5 {
             for part in value.iter_mut() {
                 let digit = u64::from(*part) + 1u64;
@@ -55,6 +66,7 @@ fn rescale<const ROUND: bool>(value: &mut [u32; 3], value_scale: &mut u32, new_s
             }
         }
         *value_scale = new_scale;
+        discarded
     } else {
         // Scale up by multiplying by powers of 10, in chunks of up to 9 while they fit within 96
         // bits. Once a chunk would overflow we fall back to multiplying one digit at a time so we
@@ -76,12 +88,8 @@ fn rescale<const ROUND: bool>(value: &mut [u32; 3], value_scale: &mut u32, new_s
             }
         }
         *value_scale = new_scale.wrapping_sub(diff);
+        false
     }
-}
-
-#[inline]
-pub(crate) fn truncate_internal(value: &mut [u32; 3], value_scale: &mut u32, desired_scale: u32) {
-    rescale::<false>(value, value_scale, desired_scale);
 }
 
 #[cfg(feature = "legacy-ops")]

--- a/src/ops/mul.rs
+++ b/src/ops/mul.rs
@@ -14,8 +14,8 @@ pub(crate) fn mul_impl(d1: &Decimal, d2: &Decimal) -> CalculationResult {
     let negative = d1.is_sign_negative() ^ d2.is_sign_negative();
 
     // See if we can optimize this calculation depending on whether the hi bits are set
-    if d1.hi() | d1.mid() == 0 {
-        if d2.hi() | d2.mid() == 0 {
+    if d1.hi() == 0 && d2.hi() == 0 {
+        if d1.mid() | d2.mid() == 0 {
             // We're multiplying two 32 bit integers, so we can take some liberties to optimize this.
             let mut low64 = d1.lo() as u64 * d2.lo() as u64;
             if scale > Decimal::MAX_SCALE {
@@ -52,8 +52,20 @@ pub(crate) fn mul_impl(d1: &Decimal, d2: &Decimal) -> CalculationResult {
             ));
         }
 
-        // We know that the left hand side is just 32 bits but the right hand side is either
-        // 64 or 96 bits.
+        // Both operands fit within 64 bits, so the full product fits within 128 bits and can be
+        // computed with a single widening multiply rather than the 32-bit limb schoolbook.
+        let m1 = (d1.lo() as u64) | ((d1.mid() as u64) << 32);
+        let m2 = (d2.lo() as u64) | ((d2.mid() as u64) << 32);
+        let product = m1 as u128 * m2 as u128;
+        let mut buffer = Buf24::zero();
+        buffer.set_low64(product as u64);
+        buffer.set_mid64((product >> 64) as u64);
+        return finish_mul(buffer, negative, scale);
+    }
+
+    if d1.mid() | d1.hi() == 0 {
+        // We know that the left hand side is just 32 bits but the right hand side is
+        // 96 bits.
         let mut product = Buf24::zero();
         mul_by_32bit_lhs(d1.lo() as u64, d2, &mut product);
         finish_mul(product, negative, scale)


### PR DESCRIPTION
I've had a few notes of performance ideas to implement recently, and decided to try them out. The results of them are this PR - with varying levels of success (I was hoping to have some more, but the negative path regressed more than I wanted). This is the result of the acceptable results.

TLDR; this adds fast paths and reduces redundant work across the hottest operations.

## Changes

* **Multiplication**: when both operands fit in 64 bits, compute the product with a single `u128` widening multiply instead of the 32-bit path.
* **Addition / subtraction**: added a `u128` fast path for 64-bit operands. Scales are aligned and the add/sub is done in 128-bit arithmetic, committing only when the result fits in 96 bits (otherwise it falls through to the existing path).
* **Rescale**: `rescale_internal` scales up/down in chunks of up to 9 digits (powers of 10) rather than one digit at a time, cutting up to 28 sequential divisions/multiplications down to <= 4. Rounding semantics are preserved. This is the one I'm most excited about since it's a hot path.
* **Normalize / Hash**: added an odd-mantissa early return (an odd mantissa can't be divisible by 10, so it has no trailing zeros to strip). `Hash` benefits for free since it normalizes every value.
* **`floor` / `ceil`**: `truncate_internal` now reports whether a nonzero fraction was discarded, so `floor`/`ceil` truncate once instead of calling `trunc()` twice plus a full subtraction via `fract()`.
* **Equality**: `PartialEq` short-circuits on identical bit patterns (the common dedup/lookup case) before falling back to the full comparison.
* **Benchmarks**: added `benches/perf_ops.rs` which is representative of 64/96-bit operands including the worst-case/fall-through.

| Operation  | Input shape                                     |   Before |    After | Delta    |
| ---------- | ----------------------------------------------- | -------: | -------: | :------- |
| `mul`      | 64-bit operands                                 |  4.03 ns |  3.73 ns | -7%      |
| `mul`      | 96-bit operand                                  | 13.17 ns | 13.09 ns | ~0%      |
| `add`      | 64-bit, same scale                              |  2.93 ns |  2.74 ns | -17%     |
| `add`      | 64-bit, mixed scale                             |  5.36 ns |  3.27 ns | -40%     |
| `add`      | 64-bit, sum overflows 96 bits _(fall-through)_  | 16.70 ns | 18.30 ns |  **+12%** |
| `sub`      | 64-bit, mixed scale                             |  5.42 ns |  3.17 ns | -41%     |
| `rescale`  | scale up                                        | 15.83 ns |  3.81 ns | -76%     |
| `rescale`  | scale down                                      | 16.14 ns |  5.07 ns | -68%     |
| `trunc`    | 96-bit                                          | 18.90 ns |  4.70 ns | -75%     |
| `round_dp` | 96-bit                                          | 12.69 ns | 12.78 ns | ~0%      |
| `normalize`| odd mantissa                                    |  2.84 ns |  2.23 ns | -21%     |
| `normalize`| even, no trailing zeros                         |  2.81 ns |  2.85 ns | ~0%      |
| `normalize`| even, trailing zeros                            | 15.00 ns | 15.10 ns | ~0%      |
| `hash`     | —                                               | 24.50 ns | 24.50 ns | ~0%      |
| `ceil`     | positive w/ fraction                            | 24.20 ns |  7.20 ns | -70%     |
| `floor`    | positive w/ fraction _(no-op branch)_           |  5.49 ns |  5.60 ns |  **+2%**  |
| `eq`       | identical bits                                  |  4.27 ns |  1.59 ns | -63%     |
| `eq`       | differ in first limb _(fall-through)_           |  4.27 ns |  4.86 ns |  **+11%** |
| `eq`       | differ only in sign/scale flags _(fall-through)_|  2.67 ns |  2.87 ns |  **+6%**  |
| `eq`       | equal value, different scale _(fall-through)_   |  4.97 ns |  6.12 ns |  **+17%** |

Notes on the regressions:

* `eq` misses cost up to 4 extra `u32` compares before `cmp` runs (~0.2 - 1 ns). Overall, it's a net win because identical-key comparisons (the dominant case in maps/dedup) drop ~63%.
* `add`/`sub` overflow fall-through (large value + large scale gap) does the `u128` work, detects the > 96-bit result, and discards it: ~1.6 ns wasted on a rare shape, against 17 - 41% on common 64-bit adds.
* `floor` no-op branch is within noise allowance.
