### PR TITLE
General clippy cleanup

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1145,6 +1145,7 @@ impl Decimal {
     /// Returns `true` if the decimal is negative.
     #[deprecated(since = "0.6.3", note = "please use `is_sign_negative` instead")]
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // kept as-is for backwards compatibility only
     pub fn is_negative(&self) -> bool {
         self.is_sign_negative()
     }
@@ -1152,6 +1153,7 @@ impl Decimal {
     /// Returns `true` if the decimal is positive.
     #[deprecated(since = "0.6.3", note = "please use `is_sign_positive` instead")]
     #[must_use]
+    #[allow(clippy::missing_const_for_fn)] // kept as-is for backwards compatibility only
     pub fn is_positive(&self) -> bool {
         self.is_sign_positive()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/README-lib.md"))]
 #![forbid(unsafe_code)]
 #![deny(clippy::print_stdout, clippy::print_stderr)]
+#![warn(clippy::missing_const_for_fn)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 extern crate alloc;

--- a/src/ops/add.rs
+++ b/src/ops/add.rs
@@ -149,7 +149,7 @@ fn add_sub_internal(d1: &Decimal, d2: &Decimal, subtract: bool) -> CalculationRe
 }
 
 #[inline(always)]
-fn rescale32(num: u32, rescale_factor: i32) -> Option<u32> {
+const fn rescale32(num: u32, rescale_factor: i32) -> Option<u32> {
     if rescale_factor > MAX_I32_SCALE {
         return None;
     }
@@ -157,7 +157,7 @@ fn rescale32(num: u32, rescale_factor: i32) -> Option<u32> {
 }
 
 #[inline(always)]
-fn fast_add(lo1: u32, lo2: u32, flags: u32, subtract: bool) -> CalculationResult {
+const fn fast_add(lo1: u32, lo2: u32, flags: u32, subtract: bool) -> CalculationResult {
     if subtract {
         // Sub can't overflow because we're ensuring the bigger number always subtracts the smaller number
         if lo1 < lo2 {

--- a/src/postgres/common.rs
+++ b/src/postgres/common.rs
@@ -2,25 +2,6 @@ use crate::{
     ops::array::{div_by_u32, is_all_zero, mul_by_u32},
     Decimal,
 };
-use core::fmt;
-use std::error;
-
-#[derive(Debug, Clone)]
-pub struct InvalidDecimal {
-    inner: Option<String>,
-}
-
-impl fmt::Display for InvalidDecimal {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        if let Some(ref msg) = self.inner {
-            fmt.write_fmt(format_args!("Invalid Decimal: {}", msg))
-        } else {
-            fmt.write_str("Invalid Decimal")
-        }
-    }
-}
-
-impl error::Error for InvalidDecimal {}
 
 pub(in crate::postgres) struct PostgresDecimal<D> {
     pub neg: bool,

--- a/src/postgres/diesel.rs
+++ b/src/postgres/diesel.rs
@@ -30,7 +30,7 @@ impl<'a> TryFrom<&'a PgNumeric> for Decimal {
         let digits: Vec<u16> = digits
             .iter()
             .map(|&v| -> deserialize::Result<u16> {
-                if v < 0 || v > 9999 {
+                if !(0..=9999).contains(&v) {
                     Err(Box::from(format!("invalid digit group: {v}")))
                 } else {
                     Ok(v as u16)

--- a/src/str.rs
+++ b/src/str.rs
@@ -188,12 +188,12 @@ fn parse_str_radix_10_dispatch<const BIG: bool, const ROUND: bool>(bytes: &[u8])
 }
 
 #[inline]
-fn overflow_64(val: u64) -> bool {
+const fn overflow_64(val: u64) -> bool {
     val >= WILL_OVERFLOW_U64
 }
 
 #[inline]
-pub fn overflow_128(val: u128) -> bool {
+pub const fn overflow_128(val: u128) -> bool {
     val >= OVERFLOW_U96
 }
 


### PR DESCRIPTION
This is a general clippy cleanup:

1. Enable the `missing_const_for_fn` lint by default and add `const` where it is missing
2. Remove unused `InvalidDecimal` construct
3. Fixes a range clippy in `diesel` feature