### PR TITLE
Require rust_decimal_macros >=1.37 to avoid circular dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ postgres-types = { default-features = false, optional = true, version = "0.2" }
 proptest = { default-features = false, optional = true, features = ["std"], version = "1.0" }
 rand = { default-features = false, optional = true, version = "0.8" }
 rand-0_9 = { default-features = false, optional = true, package = "rand", version = "0.9" }
-rust_decimal_macros = { path = "macros", default-features = false, optional = true, version = "1" }
+rust_decimal_macros = { path = "macros", default-features = false, optional = true, version = "1.37.0" }
 rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.46" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
 zmij = { default-features = false, optional = true, version = "1.0" }


### PR DESCRIPTION
Fixes #810.

rust_decimal_macros moved rust_decimal to dev-dependencies in 1.37.0, breaking
the cycle. The bound here was briefly fixed in #712 then reverted a few
minutes later in ffe9495, so cargo minimal-versions check still resolves
macros down to 1.0.0, which pulls rust_decimal back in as a normal dependency
and forms the cyclic package dependency.

master isn't affected, it pins macros to =2.0.0-alpha.0.

Didn't add the CI check you mentioned on the issue. Can't validate an actual
Actions run from a fork so it felt safer as a fast follow once this lands,
happy to do both in one PR instead if you'd rather.
