### PR TITLE
Fix round_sf returning an extra significant figure when rounding carries

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1611,22 +1611,6 @@ impl Decimal {
         self.round_sf_with_strategy(digits, RoundingStrategy::MidpointNearestEven)
     }
 
-    // Counts the digits making up the mantissa, ignoring sign and scale - effectively a naive
-    // log10. Zero has no significant figures.
-    fn significant_figures(&self) -> u32 {
-        let mut working = self.mantissa_array3();
-        let mut count = 0;
-        while !ops::array::is_all_zero(&working) {
-            let _remainder = ops::array::div_by_u32(&mut working, 10u32);
-            count += 1;
-            if working[2] == 0 && working[1] == 0 && working[0] == 1 {
-                count += 1;
-                break;
-            }
-        }
-        count
-    }
-
     /// Returns `Some(Decimal)` number rounded to the specified number of significant digits. If
     /// the resulting number is unable to be represented by the `Decimal` number then `None` will
     /// be returned.
@@ -1670,8 +1654,19 @@ impl Decimal {
             return Some(Decimal::ZERO);
         }
 
-        // We start by figuring out how many significant figures the mantissa is made up of.
-        let mantissa_sf = self.significant_figures();
+        // We start by grabbing the mantissa and figuring out how many significant figures it is
+        // made up of. We do this by just dividing by 10 and checking remainders - effectively
+        // we're performing a naive log10.
+        let mut working = self.mantissa_array3();
+        let mut mantissa_sf = 0;
+        while !ops::array::is_all_zero(&working) {
+            let _remainder = ops::array::div_by_u32(&mut working, 10u32);
+            mantissa_sf += 1;
+            if working[2] == 0 && working[1] == 0 && working[0] == 1 {
+                mantissa_sf += 1;
+                break;
+            }
+        }
         let scale = self.scale();
 
         match digits.cmp(&mantissa_sf) {
@@ -1738,6 +1733,8 @@ impl Decimal {
                     // becomes exactly 10^digits (e.g. 0.95 -> 1.0). The gained figure is a
                     // trailing zero, so dropping it is exact. Integral carries (e.g. 9.95 -> 10)
                     // have scale 0 and no significant trailing zero, so are left as-is.
+                    // There is a potential performance improvement here by pre-calculating the powers of 10
+                    // (we have this as POWERS_10 and BIG_POWERS_10 however none go to the 28th power)
                     if rounded.scale() > 0 && rounded.mantissa().unsigned_abs() == 10_u128.pow(digits) {
                         Some(rounded.round_dp_with_strategy(rounded.scale() - 1, strategy))
                     } else {

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1611,6 +1611,22 @@ impl Decimal {
         self.round_sf_with_strategy(digits, RoundingStrategy::MidpointNearestEven)
     }
 
+    // Counts the digits making up the mantissa, ignoring sign and scale - effectively a naive
+    // log10. Zero has no significant figures.
+    fn significant_figures(&self) -> u32 {
+        let mut working = self.mantissa_array3();
+        let mut count = 0;
+        while !ops::array::is_all_zero(&working) {
+            let _remainder = ops::array::div_by_u32(&mut working, 10u32);
+            count += 1;
+            if working[2] == 0 && working[1] == 0 && working[0] == 1 {
+                count += 1;
+                break;
+            }
+        }
+        count
+    }
+
     /// Returns `Some(Decimal)` number rounded to the specified number of significant digits. If
     /// the resulting number is unable to be represented by the `Decimal` number then `None` will
     /// be returned.
@@ -1654,19 +1670,8 @@ impl Decimal {
             return Some(Decimal::ZERO);
         }
 
-        // We start by grabbing the mantissa and figuring out how many significant figures it is
-        // made up of. We do this by just dividing by 10 and checking remainders - effectively
-        // we're performing a naive log10.
-        let mut working = self.mantissa_array3();
-        let mut mantissa_sf = 0;
-        while !ops::array::is_all_zero(&working) {
-            let _remainder = ops::array::div_by_u32(&mut working, 10u32);
-            mantissa_sf += 1;
-            if working[2] == 0 && working[1] == 0 && working[0] == 1 {
-                mantissa_sf += 1;
-                break;
-            }
-        }
+        // We start by figuring out how many significant figures the mantissa is made up of.
+        let mantissa_sf = self.significant_figures();
         let scale = self.scale();
 
         match digits.cmp(&mantissa_sf) {
@@ -1727,7 +1732,17 @@ impl Decimal {
                     }
                     Some(num)
                 } else {
-                    Some(self.round_dp_with_strategy(scale - diff, strategy))
+                    let rounded = self.round_dp_with_strategy(scale - diff, strategy);
+                    // Rounding away the low digits leaves `digits` figures unless the round up
+                    // carried into a new leading digit, which happens only when the mantissa
+                    // becomes exactly 10^digits (e.g. 0.95 -> 1.0). The gained figure is a
+                    // trailing zero, so dropping it is exact. Integral carries (e.g. 9.95 -> 10)
+                    // have scale 0 and no significant trailing zero, so are left as-is.
+                    if rounded.scale() > 0 && rounded.mantissa().unsigned_abs() == 10_u128.pow(digits) {
+                        Some(rounded.round_dp_with_strategy(rounded.scale() - 1, strategy))
+                    } else {
+                        Some(rounded)
+                    }
                 }
             }
             Ordering::Equal => {

--- a/tests/decimal_tests/rounding.rs
+++ b/tests/decimal_tests/rounding.rs
@@ -410,3 +410,143 @@ fn round_sf_large_digits_does_not_overflow() {
     assert!(dec!(-1.5).round_sf(u32::MAX).is_some());
     assert!(Decimal::MAX.round_sf(u32::MAX).is_some());
 }
+
+#[test]
+fn round_sf_does_not_add_figures_on_carry() {
+    // A round up that carries into a new leading digit (e.g. 0.95 -> 1.0) must not keep the
+    // trailing zero: it is significant here, giving one more figure than requested.
+    let tests = &[
+        ("0.95", 1u32, "1"),
+        ("0.99", 1, "1"),
+        ("0.995", 2, "1.0"),
+        ("0.099", 1, "0.1"),
+        ("0.0095", 1, "0.01"),
+        ("0.0099", 1, "0.01"),
+        ("9.95", 2, "10"),
+        ("99.95", 3, "100"),
+        ("9999999.95", 8, "10000000"),
+        ("99999999999999999999.95", 21, "100000000000000000000"),
+        ("0.000000000000000000000000095", 1, "0.0000000000000000000000001"),
+        ("-0.95", 1, "-1"),
+        ("-0.995", 2, "-1.0"),
+        ("-9.95", 2, "-10"),
+    ];
+    for &(input, sf, expected) in tests {
+        let input = Decimal::from_str(input).unwrap();
+        let result = input.round_sf(sf).unwrap();
+        assert_eq!(expected, result.to_string(), "{input}.round_sf({sf})");
+        // an already rounded value must round to itself
+        let again = result.round_sf(sf).unwrap();
+        assert_eq!(
+            result.serialize(),
+            again.serialize(),
+            "{input}.round_sf({sf}) is not idempotent"
+        );
+    }
+}
+
+#[test]
+fn round_sf_carry_respects_rounding_strategy() {
+    let tests = &[
+        ("0.95", 1u32, RoundingStrategy::MidpointAwayFromZero, "1"),
+        ("0.95", 1, RoundingStrategy::MidpointTowardZero, "0.9"),
+        ("0.96", 1, RoundingStrategy::MidpointAwayFromZero, "1"),
+        ("0.91", 1, RoundingStrategy::AwayFromZero, "1"),
+        ("0.0949", 1, RoundingStrategy::AwayFromZero, "0.1"),
+        ("0.994", 2, RoundingStrategy::AwayFromZero, "1.0"),
+        ("0.99", 1, RoundingStrategy::ToPositiveInfinity, "1"),
+        ("-0.99", 1, RoundingStrategy::ToNegativeInfinity, "-1"),
+        ("-0.99", 1, RoundingStrategy::ToZero, "-0.9"),
+    ];
+    for &(input, sf, strategy, expected) in tests {
+        let input = Decimal::from_str(input).unwrap();
+        let result = input.round_sf_with_strategy(sf, strategy).unwrap();
+        assert_eq!(
+            expected,
+            result.to_string(),
+            "{input}.round_sf_with_strategy({sf}, {strategy:?})"
+        );
+    }
+}
+
+#[test]
+fn round_sf_keeps_legitimate_trailing_zeros() {
+    let tests = &[
+        // the carry stops before adding a digit: the trailing zero is significant
+        ("2.95", 2u32, "3.0"),
+        ("1.00", 2, "1.0"),
+        ("10.0", 3, "10.0"),
+        ("9.95", 3, "9.95"),
+        // integral result: the scale cannot go negative
+        ("99.5", 2, "100"),
+        ("0.045", 1, "0.04"),
+        ("0.012301", 3, "0.0123"),
+        ("0", 5, "0"),
+    ];
+    for &(input, sf, expected) in tests {
+        let input = Decimal::from_str(input).unwrap();
+        let result = input.round_sf(sf).unwrap();
+        assert_eq!(expected, result.to_string(), "{input}.round_sf({sf})");
+    }
+}
+
+// Figures shown by `to_string`: for integral values trailing zeros are placeholders, not
+// significant.
+fn displayed_figures(value: &Decimal) -> u32 {
+    let digits = value.mantissa().unsigned_abs().to_string();
+    let digits = digits.trim_start_matches('0');
+    let digits = if value.scale() == 0 {
+        digits.trim_end_matches('0')
+    } else {
+        digits
+    };
+    digits.len() as u32
+}
+
+#[test]
+fn round_sf_carry_sweep_keeps_requested_figures() {
+    let strategies = &[
+        RoundingStrategy::MidpointNearestEven,
+        RoundingStrategy::MidpointAwayFromZero,
+        RoundingStrategy::MidpointTowardZero,
+        RoundingStrategy::ToZero,
+        RoundingStrategy::AwayFromZero,
+        RoundingStrategy::ToNegativeInfinity,
+        RoundingStrategy::ToPositiveInfinity,
+    ];
+    // deterministic xorshift, biased towards all-nines runs where rounding carries
+    let mut state = 0x9E37_79B9_7F4A_7C15u64;
+    let mut next = move || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    for i in 0..2000 {
+        let power = 10i128.pow((next() % 26) as u32 + 1);
+        let mantissa = match i % 3 {
+            0 => power - (next() % 100) as i128,
+            1 => power + (next() % 100) as i128,
+            _ => (next() as i128) % power + 1,
+        };
+        let mantissa = if i % 2 == 0 { mantissa } else { -mantissa };
+        let value = Decimal::from_i128_with_scale(mantissa, (next() % 29) as u32);
+        for &strategy in strategies {
+            for sf in 1..=4u32 {
+                let Some(result) = value.round_sf_with_strategy(sf, strategy) else {
+                    continue;
+                };
+                assert!(
+                    displayed_figures(&result) <= sf,
+                    "{value}.round_sf_with_strategy({sf}, {strategy:?}) = {result} has too many figures"
+                );
+                let again = result.round_sf_with_strategy(sf, strategy).unwrap();
+                assert_eq!(
+                    result.serialize(),
+                    again.serialize(),
+                    "{value}.round_sf_with_strategy({sf}, {strategy:?}) is not idempotent"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
`round_sf` returns one more significant figure than requested when the rounding step carries into a new leading digit:

```rust
dec!(0.95).round_sf(1)  // 1.0, expected 1
dec!(9.95).round_sf(2)  // 10.0, expected 10
dec!(0.099).round_sf(1) // 0.10, expected 0.1
```

Trailing decimal zeros are significant here (the docs show `round_sf(305.459, 7) == 305.4590`), so these results carry an extra figure. It also makes `round_sf` non-idempotent: `round_sf(1.0, 1) == 1`.

The fractional branch rounds to a fixed number of decimal places, which assumes the integral digit count doesn't change; a carry through a run of nines adds one. The digit count only grows when the rounded result is exactly a power of ten, so the extra digit is always a trailing zero and dropping it is exact. Integral results (`9.95 -> 10`) are left as they are since the scale cannot go negative and their trailing zero isn't significant there.

The mantissa digit-count loop is extracted into a private helper so the carry check can reuse it. Tests cover the carry at several magnitudes and strategies, the legitimate trailing-zero cases, and a deterministic sweep asserting the figure count and idempotence for every strategy.
