### PR TITLE
Cap round_sf up-scaling at MAX_SCALE

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -1671,13 +1671,18 @@ impl Decimal {
 
         match digits.cmp(&mantissa_sf) {
             Ordering::Greater => {
-                // If we're requesting a higher number of significant figures, we rescale
+                // If we're requesting a higher number of significant figures, we rescale. The
+                // target is capped at MAX_SCALE: a Decimal cannot store a higher scale, and an
+                // uncapped value would be malformed (scale 29-31) and panic on Display.
                 let mut array = [self.lo, self.mid, self.hi];
                 let mut value_scale = scale;
                 ops::array::rescale_internal(
                     &mut array,
                     &mut value_scale,
-                    scale.saturating_add(digits).saturating_sub(mantissa_sf),
+                    scale
+                        .saturating_add(digits)
+                        .saturating_sub(mantissa_sf)
+                        .min(MAX_SCALE_U32),
                 );
                 Some(Decimal {
                     lo: array[0],

--- a/tests/decimal_tests/rounding.rs
+++ b/tests/decimal_tests/rounding.rs
@@ -550,3 +550,60 @@ fn round_sf_carry_sweep_keeps_requested_figures() {
         }
     }
 }
+
+#[test]
+fn round_sf_up_scale_stays_within_max_scale() {
+    // Requesting more figures than the magnitude holds up-scales the value by padding zeros. The
+    // target scale must be capped at MAX_SCALE: an uncapped target produced a malformed scale
+    // 29-31 Decimal (e.g. 5e-27.round_sf(5) -> scale 31) that then panics on `to_string`.
+    let strategies = &[
+        RoundingStrategy::MidpointNearestEven,
+        RoundingStrategy::MidpointAwayFromZero,
+        RoundingStrategy::MidpointTowardZero,
+        RoundingStrategy::ToZero,
+        RoundingStrategy::AwayFromZero,
+        RoundingStrategy::ToNegativeInfinity,
+        RoundingStrategy::ToPositiveInfinity,
+    ];
+    // (input, digits, expected) - up-scaling only pads zeros, so every strategy agrees.
+    let tests = &[
+        // over the boundary: without the cap these were scale 29/30/31
+        ("0.000000000000000000000000005", 5u32, "0.0000000000000000000000000050"),
+        ("0.000000000000000000000000005", 4, "0.0000000000000000000000000050"),
+        ("0.000000000000000000000000005", 3, "0.0000000000000000000000000050"),
+        ("-0.000000000000000000000000005", 5, "-0.0000000000000000000000000050"),
+        ("0.05", 28, "0.0500000000000000000000000000"),
+        ("0.005", 27, "0.0050000000000000000000000000"),
+        ("0.5", 29, "0.5000000000000000000000000000"),
+        ("-0.5", 30, "-0.5000000000000000000000000000"),
+        // in range: the cap does not interfere with normal up-scaling
+        ("0.5", 3, "0.500"),
+        ("305.459", 7, "305.4590"),
+    ];
+    for &(input, digits, expected) in tests {
+        let value = Decimal::from_str(input).unwrap();
+        for &strategy in strategies {
+            let result = value
+                .round_sf_with_strategy(digits, strategy)
+                .expect("up-scaling a representable value must not return None");
+            assert!(
+                result.scale() <= Decimal::MAX_SCALE,
+                "{input}.round_sf_with_strategy({digits}, {strategy:?}) scale {} exceeds MAX_SCALE",
+                result.scale()
+            );
+            // `to_string` panics on a malformed scale, so this also guards the crash.
+            assert_eq!(
+                expected,
+                result.to_string(),
+                "{input}.round_sf_with_strategy({digits}, {strategy:?})"
+            );
+            // an already up-scaled value must round to itself
+            let again = result.round_sf_with_strategy(digits, strategy).unwrap();
+            assert_eq!(
+                result.serialize(),
+                again.serialize(),
+                "{input}.round_sf_with_strategy({digits}, {strategy:?}) is not idempotent"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`round_sf` / `round_sf_with_strategy` up-scale the value when you request more significant figures than its magnitude holds. The target scale (`scale + digits - mantissa_sf`) wasn't bounded by `MAX_SCALE` (28), so it could return a `Decimal` with scale 29–31. Scale 31 panics on `Display`:

```rust
let d = Decimal::from_str("0.000000000000000000000000005").unwrap(); // 5e-27
println!("{}", d.round_sf(5).unwrap()); // panic: CapacityError at src/str.rs
```

Scale 29/30 don't panic but are still out of range (`0.05.round_sf(28)` → scale 29, `0.5.round_sf(29)` → scale 29). It's strategy-independent, since the up-scale runs before the strategy is applied. This is the up-scale sibling of #815's carry fix — same function, `Ordering::Greater` instead of `Ordering::Less`.

Fix: cap the target at `MAX_SCALE`. The value itself is representable (only the extra trailing zeros aren't), so the result is the value at max scale — `5e-27.round_sf(5)` → `0.0000000000000000000000000050`. That's already how `round_sf(u32::MAX)` behaves (`round_sf_large_digits_does_not_overflow`).

The doc says an unrepresentable result should be `None`, so returning `None` here is defensible too — but it reads the doc more strictly than current behavior: `1.5.round_sf(u32::MAX)` is `Some` today and `None` would regress that test. I went with the cap to keep the value; happy to switch to `None` if you'd rather.

Scope: checked the rest of the family against Python's `decimal` — `round_dp*` return early without up-scaling and `trunc*` only reduce scale, so neither can exceed `MAX_SCALE`. The shared `rescale_internal` can also produce scale 29–31 via the public `rescale()`, but that path looks intentional (issue #618 makes arithmetic on those values correct rather than clamping), so I left it untouched.

Test `round_sf_up_scale_stays_within_max_scale`: boundary/over-boundary inputs × all 7 strategies, asserting scale ≤ `MAX_SCALE` and that `to_string` doesn't panic, plus idempotence and in-range controls.
