### PR TITLE
Remove rkyv 0.7 from feature bridge and update rand 0.8 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,9 @@ ndarray = { default-features = false, optional = true, version = "0.15.6" }
 num-traits = { default-features = false, features = ["i128"], version = "0.2" }
 postgres-types = { default-features = false, optional = true, version = "0.2" }
 proptest = { default-features = false, optional = true, features = ["std"], version = "1.0" }
-rand = { default-features = false, optional = true, version = "0.8" }
+rand = { default-features = false, optional = true, version = "0.8.6" }
 rand-0_9 = { default-features = false, optional = true, package = "rand", version = "0.9" }
 rust_decimal_macros = { path = "macros", default-features = false, optional = true, version = "1.37.0" }
-rkyv = { default-features = false, features = ["size_32", "std"], optional = true, version = "0.7.46" }
 rocket = { default-features = false, optional = true, version = "0.5.0-rc.3" }
 zmij = { default-features = false, optional = true, version = "1.0" }
 serde = { default-features = false, optional = true, version = "1.0" }
@@ -62,7 +61,7 @@ bytes = { default-features = false, version = "1.0" }
 diesel = { default-features = false, features = ["mysql", "postgres"], version = "2.2.3" }
 futures = { default-features = false, version = "0.3" }
 postgres = { default-features = false, version = "0.19" }
-rand = { default-features = false, features = ["getrandom"], version = "0.8" }
+rand = { default-features = false, features = ["getrandom"], version = "0.8.6" }
 rust_decimal = { path = ".", features = ["macros"] }
 rand-0_9 = { default-features = false, features = ["thread_rng"], package = "rand", version = "0.9" }
 rkyv-0_8 = { version = "0.8.13", package = "rkyv" }
@@ -90,8 +89,6 @@ ndarray = ["dep:ndarray"]
 proptest = ["dep:proptest"]
 rand = ["dep:rand"]
 rand-0_9 = ["dep:rand-0_9"]
-rkyv = ["dep:rkyv"]
-rkyv-safe = ["rkyv/validation"]
 rocket-traits = ["dep:rocket", "std"]
 rust-fuzz = ["dep:arbitrary"]
 serde = ["dep:serde", "wasm-bindgen?/serde"]
@@ -102,7 +99,7 @@ serde-str = ["serde-with-str"]
 serde-with-arbitrary-precision = ["serde", "serde_json/arbitrary_precision", "serde_json/std", "zmij"]
 serde-with-float = ["serde"]
 serde-with-str = ["serde"]
-std = ["arrayvec/std", "wasm-bindgen?/std", "borsh?/std", "bytes?/std", "rand?/std", "rkyv?/std", "serde?/std", "serde_json?/std"]
+std = ["arrayvec/std", "wasm-bindgen?/std", "borsh?/std", "bytes?/std", "rand?/std", "rand-0_9?/std", "serde?/std", "serde_json?/std"]
 tokio-pg = ["db-tokio-postgres"] # Backwards compatability
 wasm = ["dep:wasm-bindgen"]
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ assert_eq!(total, dec!(27.26));
 * [macros](#macros)
 * [maths](#maths)
 * [ndarray](#ndarray)
-* [rkyv](#rkyv)
 * [rocket-traits](#rocket-traits)
 * [rust-fuzz](#rust-fuzz)
 * [std](#std)
@@ -225,14 +224,38 @@ two).
 
 ### `rkyv`
 
-Enables [rkyv](https://github.com/rkyv/rkyv) serialization for `Decimal`. In order to avoid breaking changes, this is
-currently locked at version `0.7`.
+Removed in `1.43.0`. This feature previously enabled [rkyv](https://github.com/rkyv/rkyv) `0.7` serialization for
+`Decimal`. The `0.7` line is no longer supported upstream and will not receive further fixes
+(see [RUSTSEC-2026-0235](https://rustsec.org/advisories/RUSTSEC-2026-0235.html)), so it was carried in every downstream
+lockfile regardless of whether the feature was enabled.
 
-Supports rkyv's safe API when the `rkyv-safe` feature is enabled as well.
+Use rkyv's [remote derives](https://rkyv.org/derive-macro-features/remote-derive.html) instead. These work against any
+rkyv version without `rust_decimal` needing to depend on rkyv at all, and are demonstrated in `examples/rkyv-remote`:
 
-If `rkyv` support for versions `0.8` of greater is desired, `rkyv`'
-s [remote derives](https://rkyv.org/derive-macro-features/remote-derive.html) should be used instead. See
-`examples/rkyv-remote`.
+```ignore
+use rkyv::{rancor::Error, Archive, Deserialize, Serialize};
+use rust_decimal::prelude::{dec, Decimal};
+
+#[derive(Archive, Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct Root {
+    #[rkyv(with = RkyvDecimal)]
+    decimal: Decimal,
+}
+
+/// Archived layout of `Decimal`
+#[derive(Archive, Serialize, Deserialize)]
+#[rkyv(remote = Decimal)]
+struct RkyvDecimal {
+    #[rkyv(getter = Decimal::serialize)]
+    bytes: [u8; 16],
+}
+
+impl From<RkyvDecimal> for Decimal {
+    fn from(RkyvDecimal { bytes }: RkyvDecimal) -> Self {
+        Self::deserialize(bytes)
+    }
+}
+```
 
 ### `rocket-traits`
 

--- a/make/tests/misc.toml
+++ b/make/tests/misc.toml
@@ -4,7 +4,6 @@ dependencies = [
     "test-rust-fuzz",
     "test-rocket-traits",
     "test-borsh",
-    "test-rkyv",
     "test-rand"
 ]
 
@@ -27,10 +26,6 @@ args = ["test", "--workspace", "--features=borsh", "borsh_tests", "--", "--skip"
 [tasks.test-ndarray]
 command = "cargo"
 args = ["test", "--workspace", "--features=ndarray", "nd_array_tests", "--", "--skip", "generated"]
-
-[tasks.test-rkyv]
-command = "cargo"
-args = ["test", "--workspace", "--features=rkyv", "--features=rkyv-safe", "rkyv_tests", "--", "--skip", "generated"]
 
 [tasks.test-rand]
 dependencies = [

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -21,8 +21,6 @@ use diesel::{deserialize::FromSqlRow, expression::AsExpression, sql_types::Numer
 #[cfg(not(feature = "std"))]
 use num_traits::float::FloatCore;
 use num_traits::{FromPrimitive, Num, One, Signed, ToPrimitive, Zero};
-#[cfg(feature = "rkyv")]
-use rkyv::{Archive, Deserialize, Serialize};
 #[cfg(all(target_arch = "wasm32", feature = "wasm"))]
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -124,13 +122,6 @@ impl From<UnpackedDecimal> for Decimal {
     derive(borsh::BorshDeserialize, borsh::BorshSerialize, borsh::BorshSchema)
 )]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck_derive::Pod, bytemuck_derive::Zeroable))]
-#[cfg_attr(
-    feature = "rkyv",
-    derive(Archive, Deserialize, Serialize),
-    archive(compare(PartialEq)),
-    archive_attr(derive(Clone, Copy, Debug))
-)]
-#[cfg_attr(feature = "rkyv-safe", archive(check_bytes))]
 #[cfg_attr(all(target_arch = "wasm32", feature = "wasm"), wasm_bindgen)]
 pub struct Decimal {
     // Bits 0-15: unused

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -236,38 +236,6 @@ mod ndarray_tests {
     }
 }
 
-#[cfg(feature = "rkyv")]
-mod rkyv_tests {
-    use rust_decimal::Decimal;
-    use std::str::FromStr;
-
-    #[test]
-    fn it_can_serialize_deserialize_rkyv() {
-        use rkyv::Deserialize;
-        let tests = [
-            "12.3456789",
-            "5233.9008808150288439427720175",
-            "-5233.9008808150288439427720175",
-        ];
-        for test in &tests {
-            let a = Decimal::from_str(test).unwrap();
-            let bytes = rkyv::to_bytes::<_, 256>(&a).unwrap();
-
-            #[cfg(feature = "rkyv-safe")]
-            {
-                let archived = rkyv::check_archived_root::<Decimal>(&bytes[..]).unwrap();
-                assert_eq!(archived, &a);
-            }
-
-            let archived = unsafe { rkyv::archived_root::<Decimal>(&bytes[..]) };
-            assert_eq!(archived, &a);
-
-            let deserialized: Decimal = archived.deserialize(&mut rkyv::Infallible).unwrap();
-            assert_eq!(deserialized, a);
-        }
-    }
-}
-
 #[test]
 fn it_can_deserialize_unbounded_values() {
     // Mantissa for these: 19393111376951473493673267553


### PR DESCRIPTION
Fixes two RUSTSEC advisories from downstream optional dependencies.
1. Removes `rkyv` 0.7 support (somewhat controversially) to address #818  
2. Updates `rand` dependency to 0.8.6 to fix #792 

My reasoning:
> I'm tempted to break semver slightly and rip out rkyv v0.7. At the moment, we're keeping this feature for a small subset of users that are likely being pressured to upgrade rkyv nonetheless. This comes at the cost of inconveniencing the entire ecosystem (at least those using cargo audit/cargo deny).

I'm open to feedback on this approach however since it is somewhat controversial. It comes from a position where we're dependent on downstream libraries maintaining legacy versions of their product.