### PR TITLE
Fix Signed::is_positive/is_negative returning true for zero (#787)

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2018,11 +2018,11 @@ impl Signed for Decimal {
     }
 
     fn is_positive(&self) -> bool {
-        self.is_sign_positive()
+        !self.is_zero() && self.is_sign_positive()
     }
 
     fn is_negative(&self) -> bool {
-        self.is_sign_negative()
+        !self.is_zero() && self.is_sign_negative()
     }
 }
 

--- a/tests/decimal_tests/misc.rs
+++ b/tests/decimal_tests/misc.rs
@@ -51,6 +51,24 @@ fn it_can_calculate_signum() {
 }
 
 #[test]
+fn signed_zero_is_neither_positive_nor_negative() {
+    // #787: num_traits::Signed::is_positive / is_negative must be false for
+    // zero (and negative zero), matching the trait's contract and signum().
+    let mut negative_zero = Decimal::ZERO;
+    negative_zero.set_sign_negative(true);
+
+    assert!(!Decimal::ZERO.is_positive());
+    assert!(!Decimal::ZERO.is_negative());
+    assert!(!negative_zero.is_positive());
+    assert!(!negative_zero.is_negative());
+
+    assert!(Decimal::ONE.is_positive());
+    assert!(!Decimal::ONE.is_negative());
+    assert!(Decimal::NEGATIVE_ONE.is_negative());
+    assert!(!Decimal::NEGATIVE_ONE.is_positive());
+}
+
+#[test]
 fn it_can_calculate_abs_sub() {
     let tests = &[
         ("123", "124", 0),


### PR DESCRIPTION
Fixes #787.

### Problem

`num_traits::Signed` requires `is_positive` to return `false` for zero and `is_negative` to return `false` for zero (and negative zero). The `Decimal` implementation delegated straight to the sign bit:

```rust
fn is_positive(&self) -> bool { self.is_sign_positive() }   // true for ZERO
fn is_negative(&self) -> bool { self.is_sign_negative() }   // true for -0
```

So `Decimal::ZERO.is_positive()` returned `true` and a negative zero's `is_negative()` returned `true`, breaking the trait contract for any generic numeric code that relies on `Decimal: Signed`.

### Fix

Exclude zero, matching the contract and the sibling `signum()` in the same impl, which already special-cases `is_zero()`:

```rust
fn is_positive(&self) -> bool { !self.is_zero() && self.is_sign_positive() }
fn is_negative(&self) -> bool { !self.is_zero() && self.is_sign_negative() }
```

### Test

Added `signed_zero_is_neither_positive_nor_negative` in `tests/decimal_tests/misc.rs`. Red-green verified with `cargo test`: before the change the test fails on `!Decimal::ZERO.is_positive()`; after, zero and negative zero are neither positive nor negative while `ONE`/`NEGATIVE_ONE` are unchanged. `cargo fmt --check` and `clippy` (on the change) are clean.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I verified the contract against num_traits, ran the tests (red-green), and take responsibility for the contribution.
