### PR TITLE
Add `#[track_caller]` to arithmetic operators (closes #733)

### DIFF
--- a/src/arithmetic_impls.rs
+++ b/src/arithmetic_impls.rs
@@ -117,6 +117,7 @@ macro_rules! forward_ref_val_binop {
             type Output = $res;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: $res) -> $res {
                 self.$method(&other)
             }
@@ -130,6 +131,7 @@ macro_rules! forward_val_ref_binop {
             type Output = $res;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: &$res) -> $res {
                 (&self).$method(other)
             }
@@ -143,6 +145,7 @@ macro_rules! forward_val_val_binop {
             type Output = $res;
 
             #[inline]
+            #[track_caller]
             fn $method(self, other: $res) -> $res {
                 (&self).$method(&other)
             }
@@ -155,6 +158,7 @@ impl Add<&Decimal> for &Decimal {
     type Output = Decimal;
 
     #[inline(always)]
+    #[track_caller]
     fn add(self, other: &Decimal) -> Decimal {
         match ops::add_impl(self, other) {
             CalculationResult::Ok(sum) => sum,
@@ -202,6 +206,7 @@ impl Inv for Decimal {
     type Output = Self;
 
     #[inline]
+    #[track_caller]
     fn inv(self) -> Self {
         Decimal::ONE / self
     }
@@ -212,6 +217,7 @@ impl Div<&Decimal> for &Decimal {
     type Output = Decimal;
 
     #[inline]
+    #[track_caller]
     fn div(self, other: &Decimal) -> Decimal {
         match ops::div_impl(self, other) {
             CalculationResult::Ok(quot) => quot,
@@ -226,6 +232,7 @@ impl Mul<&Decimal> for &Decimal {
     type Output = Decimal;
 
     #[inline]
+    #[track_caller]
     fn mul(self, other: &Decimal) -> Decimal {
         match ops::mul_impl(self, other) {
             CalculationResult::Ok(prod) => prod,
@@ -239,6 +246,7 @@ impl Rem<&Decimal> for &Decimal {
     type Output = Decimal;
 
     #[inline]
+    #[track_caller]
     fn rem(self, other: &Decimal) -> Decimal {
         match ops::rem_impl(self, other) {
             CalculationResult::Ok(rem) => rem,
@@ -253,6 +261,7 @@ impl Sub<&Decimal> for &Decimal {
     type Output = Decimal;
 
     #[inline(always)]
+    #[track_caller]
     fn sub(self, other: &Decimal) -> Decimal {
         match ops::sub_impl(self, other) {
             CalculationResult::Ok(sum) => sum,

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -2558,6 +2558,7 @@ impl Neg for &Decimal {
 }
 
 impl AddAssign for Decimal {
+    #[track_caller]
     fn add_assign(&mut self, other: Decimal) {
         let result = self.add(other);
         self.lo = result.lo;
@@ -2568,24 +2569,28 @@ impl AddAssign for Decimal {
 }
 
 impl<'a> AddAssign<&'a Decimal> for Decimal {
+    #[track_caller]
     fn add_assign(&mut self, other: &'a Decimal) {
         Decimal::add_assign(self, *other)
     }
 }
 
 impl AddAssign<Decimal> for &mut Decimal {
+    #[track_caller]
     fn add_assign(&mut self, other: Decimal) {
         Decimal::add_assign(*self, other)
     }
 }
 
 impl<'a> AddAssign<&'a Decimal> for &'a mut Decimal {
+    #[track_caller]
     fn add_assign(&mut self, other: &'a Decimal) {
         Decimal::add_assign(*self, *other)
     }
 }
 
 impl SubAssign for Decimal {
+    #[track_caller]
     fn sub_assign(&mut self, other: Decimal) {
         let result = self.sub(other);
         self.lo = result.lo;
@@ -2596,24 +2601,28 @@ impl SubAssign for Decimal {
 }
 
 impl<'a> SubAssign<&'a Decimal> for Decimal {
+    #[track_caller]
     fn sub_assign(&mut self, other: &'a Decimal) {
         Decimal::sub_assign(self, *other)
     }
 }
 
 impl SubAssign<Decimal> for &mut Decimal {
+    #[track_caller]
     fn sub_assign(&mut self, other: Decimal) {
         Decimal::sub_assign(*self, other)
     }
 }
 
 impl<'a> SubAssign<&'a Decimal> for &'a mut Decimal {
+    #[track_caller]
     fn sub_assign(&mut self, other: &'a Decimal) {
         Decimal::sub_assign(*self, *other)
     }
 }
 
 impl MulAssign for Decimal {
+    #[track_caller]
     fn mul_assign(&mut self, other: Decimal) {
         let result = self.mul(other);
         self.lo = result.lo;
@@ -2624,24 +2633,28 @@ impl MulAssign for Decimal {
 }
 
 impl<'a> MulAssign<&'a Decimal> for Decimal {
+    #[track_caller]
     fn mul_assign(&mut self, other: &'a Decimal) {
         Decimal::mul_assign(self, *other)
     }
 }
 
 impl MulAssign<Decimal> for &mut Decimal {
+    #[track_caller]
     fn mul_assign(&mut self, other: Decimal) {
         Decimal::mul_assign(*self, other)
     }
 }
 
 impl<'a> MulAssign<&'a Decimal> for &'a mut Decimal {
+    #[track_caller]
     fn mul_assign(&mut self, other: &'a Decimal) {
         Decimal::mul_assign(*self, *other)
     }
 }
 
 impl DivAssign for Decimal {
+    #[track_caller]
     fn div_assign(&mut self, other: Decimal) {
         let result = self.div(other);
         self.lo = result.lo;
@@ -2652,24 +2665,28 @@ impl DivAssign for Decimal {
 }
 
 impl<'a> DivAssign<&'a Decimal> for Decimal {
+    #[track_caller]
     fn div_assign(&mut self, other: &'a Decimal) {
         Decimal::div_assign(self, *other)
     }
 }
 
 impl DivAssign<Decimal> for &mut Decimal {
+    #[track_caller]
     fn div_assign(&mut self, other: Decimal) {
         Decimal::div_assign(*self, other)
     }
 }
 
 impl<'a> DivAssign<&'a Decimal> for &'a mut Decimal {
+    #[track_caller]
     fn div_assign(&mut self, other: &'a Decimal) {
         Decimal::div_assign(*self, *other)
     }
 }
 
 impl RemAssign for Decimal {
+    #[track_caller]
     fn rem_assign(&mut self, other: Decimal) {
         let result = self.rem(other);
         self.lo = result.lo;
@@ -2680,18 +2697,21 @@ impl RemAssign for Decimal {
 }
 
 impl<'a> RemAssign<&'a Decimal> for Decimal {
+    #[track_caller]
     fn rem_assign(&mut self, other: &'a Decimal) {
         Decimal::rem_assign(self, *other)
     }
 }
 
 impl RemAssign<Decimal> for &mut Decimal {
+    #[track_caller]
     fn rem_assign(&mut self, other: Decimal) {
         Decimal::rem_assign(*self, other)
     }
 }
 
 impl<'a> RemAssign<&'a Decimal> for &'a mut Decimal {
+    #[track_caller]
     fn rem_assign(&mut self, other: &'a Decimal) {
         Decimal::rem_assign(*self, *other)
     }

--- a/tests/track_caller_tests.rs
+++ b/tests/track_caller_tests.rs
@@ -1,0 +1,87 @@
+//! Verifies that panics originating from `Decimal`'s arithmetic operators are
+//! attributed to the caller's source location.
+//!
+//! The operators (and their `*Assign` counterparts) are annotated with
+//! `#[track_caller]`, so a panic such as a division by zero should report the
+//! location of the offending expression in user code rather than a line inside
+//! `rust_decimal`'s own source. See <https://github.com/paupino/rust-decimal/issues/733>.
+//!
+//! This lives in its own integration test binary because it installs a process
+//! wide panic hook; keeping it isolated avoids interfering with the panic
+//! behaviour of any other test.
+
+use rust_decimal::Decimal;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::{Mutex, OnceLock};
+
+fn captured_location() -> &'static Mutex<Option<(String, u32)>> {
+    static LOCATION: OnceLock<Mutex<Option<(String, u32)>>> = OnceLock::new();
+    LOCATION.get_or_init(|| Mutex::new(None))
+}
+
+/// Runs `operation`, which is expected to panic, and returns the `(file, line)`
+/// that the panic was attributed to.
+fn location_of_panic(operation: impl FnOnce()) -> (String, u32) {
+    *captured_location().lock().unwrap() = None;
+    let result = panic::catch_unwind(AssertUnwindSafe(operation));
+    assert!(result.is_err(), "expected the operation to panic, but it did not");
+    captured_location()
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("panic hook did not record a location")
+}
+
+#[test]
+fn arithmetic_panics_point_at_the_caller() {
+    let default_hook = panic::take_hook();
+    panic::set_hook(Box::new(|info| {
+        if let Some(location) = info.location() {
+            *captured_location().lock().unwrap() = Some((location.file().to_string(), location.line()));
+        }
+    }));
+
+    // Every operation checked below is expected to panic. Because the operators
+    // carry `#[track_caller]`, the reported file must be this test file (the
+    // caller), never `src/arithmetic_impls.rs` or `src/decimal.rs`.
+    let mut misattributed = Vec::new();
+    let mut check = |name: &str, operation: fn()| {
+        let (file, line) = location_of_panic(operation);
+        if !file.ends_with("track_caller_tests.rs") {
+            misattributed.push(format!("{name}: attributed to {file}:{line}"));
+        }
+    };
+
+    check("addition overflow", || {
+        let _ = Decimal::MAX + Decimal::MAX;
+    });
+    check("subtraction overflow", || {
+        let _ = Decimal::MIN - Decimal::MAX;
+    });
+    check("multiplication overflow", || {
+        let _ = Decimal::MAX * Decimal::MAX;
+    });
+    check("division by zero", || {
+        let _ = Decimal::ONE / Decimal::ZERO;
+    });
+    check("remainder by zero", || {
+        let _ = Decimal::ONE % Decimal::ZERO;
+    });
+    check("add-assign overflow", || {
+        let mut value = Decimal::MAX;
+        value += Decimal::MAX;
+    });
+    check("div-assign by zero", || {
+        let mut value = Decimal::ONE;
+        value /= Decimal::ZERO;
+    });
+
+    panic::set_hook(default_hook);
+
+    assert!(
+        misattributed.is_empty(),
+        "expected every arithmetic panic to be attributed to the caller, but the \
+         following were not:\n{}",
+        misattributed.join("\n"),
+    );
+}


### PR DESCRIPTION
Closes #733.

Panics from `Decimal`'s arithmetic operators currently report a source location inside `rust_decimal` rather than the caller's code. A division by zero, for instance, points at `src/arithmetic_impls.rs` instead of the offending line in the user's program, which makes it harder than it should be to find — exactly the motivation in #733.

Following the approach @Tony-Samuels sketched out in the issue, this annotates the panicking operations with `#[track_caller]` and, importantly, propagates it through the whole call chain so the attribution actually reaches the caller:

- the `Add`/`Sub`/`Mul`/`Div`/`Rem` impls on `&Decimal` that hold the `panic!`s;
- the value/reference forwarding wrappers generated by `forward_*_binop!` (each one is a call in the chain, so it needs the attribute too);
- the `*Assign` impls; and
- `Inv`, which divides and so can panic on zero.

### Testing

Added `tests/track_caller_tests.rs`. It installs a panic hook and asserts that overflow, division-by-zero and remainder-by-zero panics — from both the operators and their assigning forms — are attributed to the test file rather than the crate internals. It lives in its own integration binary since it sets a process-wide panic hook, keeping it isolated from other tests.

Before the change the hook records locations like `src/arithmetic_impls.rs:161`; afterwards they resolve to the caller. `cargo fmt`, `cargo clippy` and the existing test suite are all clean, and there are no public API or default-behaviour changes.