### PR TITLE
Add golden ratio constant

### DIFF
--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -375,6 +375,23 @@ impl Decimal {
         mid: 2857938002,
         hi: 199427844,
     };
+    /// A constant representing the golden ratio (φ) as 1.6180339887498948482045868344
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    /// ```
+    /// # use rust_decimal::Decimal;
+    /// # use rust_decimal_macros::dec;
+    /// assert_eq!(Decimal::GOLDEN_RATIO, dec!(1.6180339887498948482045868344));
+    /// ```
+    #[cfg(feature = "maths")]
+    pub const GOLDEN_RATIO: Decimal = Decimal {
+        flags: 1835008,
+        lo: 3068950840,
+        mid: 3775324002,
+        hi: 877137982,
+    };
 
     /// Returns a `Decimal` with a 64 bit `m` representation and corresponding `e` scale.
     ///

--- a/tests/decimal_tests/maths.rs
+++ b/tests/decimal_tests/maths.rs
@@ -9,6 +9,7 @@ fn test_constants() {
     assert_eq!("1.5707963267948966192313216916", Decimal::HALF_PI.to_string());
     assert_eq!("2.7182818284590452353602874714", Decimal::E.to_string());
     assert_eq!("0.3678794411714423215955237702", Decimal::E_INVERSE.to_string());
+    assert_eq!("1.6180339887498948482045868344", Decimal::GOLDEN_RATIO.to_string());
 }
 
 #[test]


### PR DESCRIPTION
Closes #667.

`PI` and `E` are already provided, so this adds the golden ratio (φ) as the missing handy constant from that issue. It follows the same pattern as the existing math constants, gated behind the `maths` feature, with the value rounded to 28 dp like the others. I added a line to the existing constants test covering it.